### PR TITLE
feat: agent-society — social interactions, factions, trading, childhood, colony UI

### DIFF
--- a/backend/app/ai/orchestrator.py
+++ b/backend/app/ai/orchestrator.py
@@ -30,11 +30,13 @@ class RealLLMOrchestrator:
         base_url: str = "http://localhost:11434",
         timeout: int = 30,
         memory: Optional[AgentMemory] = None,
+        faction_manager=None,
     ):
         self.model = model
         self.api_url = f"{base_url.rstrip('/')}/api/chat"
         self.timeout = timeout
         self.memory = memory or AgentMemory()
+        self.faction_manager = faction_manager
         self._pending: dict[str, asyncio.Future] = {}
         self._mock = MockLLMOrchestrator()
 
@@ -62,12 +64,22 @@ class RealLLMOrchestrator:
                 )
         memories = self.memory.format_recent(agent.id, n=5)
         trigger = agent.last_thought or "Time to decide what to do"
+        # Resolve faction context if available
+        faction_context = ""
+        if agent.faction_id:
+            faction = self.faction_manager.get_faction(agent.faction_id) if hasattr(self, "faction_manager") else None
+            if faction:
+                faction_context = f'- You are a member of "{faction.name}" (color: {faction.color})'
+            else:
+                faction_context = f'- You are a member of faction "{agent.faction_id}"'
         return build_agent_prompt(
             agent=agent,
             nearby_resources=nearby_resources,
             nearby_agents="none",
             memories=memories,
             trigger=trigger,
+            last_action_result=agent.last_action_result,
+            faction_context=faction_context,
         )
 
     async def check_availability(self) -> bool:

--- a/backend/app/ai/prompts.py
+++ b/backend/app/ai/prompts.py
@@ -1,5 +1,7 @@
 """Prompt templates for agent LLM interactions."""
 
+from typing import Any
+
 from app.simulation.agent import Agent
 
 SYSTEM_PROMPT_TEMPLATE = """You are {name}, a {role} in a tribal society.
@@ -26,9 +28,21 @@ STATE_PROMPT_TEMPLATE = """CURRENT STATE:
 - Inventory: {inventory}
 - Current action: {action}
 
+LAST ACTION RESULT:
+{last_action_result}
+
 NEARBY RESOURCES: {resources}
 
+KNOWLEDGE:
+{knowledge}
+
 NEARBY AGENTS: {agents}
+
+SOCIAL CONTEXT:
+{social_context}
+
+FACTION:
+{faction_context}
 
 RECENT MEMORIES:
 {memories}
@@ -43,9 +57,8 @@ Respond with ONLY this JSON format:
   "priority": "low" | "medium" | "high",
   "steps": [
     {
-      "action": "move" | "chop" | "drink" | "eat" | "gather" | "rest",
+      "action": "move" | "chop" | "drink" | "eat" | "gather" | "rest" | "trade" | "socialize" | "feed_child",
       "target": [x, y] or null,
-      "duration_secs": number (1-30),
       "reason": "Why this step"
     }
   ],
@@ -68,6 +81,9 @@ def build_agent_prompt(
     nearby_agents: str,
     memories: str,
     trigger: str,
+    last_action_result: Any = None,
+    social_context: str = "",
+    faction_context: str = "",
 ) -> str:
     """Build the full prompt for an agent LLM call."""
     personality = agent.__dict__.get("system_prompt", "") or (
@@ -76,7 +92,50 @@ def build_agent_prompt(
         f"sociability={agent.sociability}, speed={agent.speed}."
     )
 
+    # Format last action result
+    if last_action_result is None:
+        lar_str = "None (first tick)"
+    else:
+        from app.simulation.actions import ActionResult
+        if isinstance(last_action_result, ActionResult):
+            lar_str = (
+                f"- Action: {last_action_result.action_type}\n"
+                f"- Success: {last_action_result.success}\n"
+                f"- Effects: {last_action_result.action_summary}"
+            )
+        else:
+            lar_str = str(last_action_result)
+
+    # Format social context
+    if not social_context:
+        if agent.conversation_queue:
+            count = len(agent.conversation_queue)
+            latest = agent.conversation_queue[-1]
+            social_str = f"- Unread messages: {count}\n- Latest: {latest.content}"
+        else:
+            social_str = "- No pending messages"
+    else:
+        social_str = social_context
+
+    # Format faction context
+    if not faction_context:
+        if agent.faction_id:
+            faction_str = f'- You are a member of faction "{agent.faction_id}"'
+        else:
+            faction_str = "- You are not in a faction"
+    else:
+        faction_str = faction_context
+
     system = SYSTEM_PROMPT_TEMPLATE.format(name=agent.name, role=agent.role, personality=personality)
+
+    # Format knowledge
+    if agent.knowledge:
+        knowledge_str = "\n".join(
+            f"- You know: {subtype} is {props}"
+            for subtype, props in agent.knowledge.items()
+        )
+    else:
+        knowledge_str = "(you have no special knowledge yet)"
 
     state = STATE_PROMPT_TEMPLATE.format(
         x=agent.position[0],
@@ -87,8 +146,12 @@ def build_agent_prompt(
         health=agent.health,
         inventory=agent.inventory or {},
         action=agent.current_action or "idle",
+        last_action_result=lar_str,
         resources=nearby_resources,
+        knowledge=knowledge_str,
         agents=nearby_agents,
+        social_context=social_str,
+        faction_context=faction_str,
         memories=memories,
         trigger=trigger,
     )

--- a/backend/app/api/colony.py
+++ b/backend/app/api/colony.py
@@ -1,0 +1,35 @@
+"""Colony stats REST endpoint."""
+
+from fastapi import APIRouter, Request
+
+router = APIRouter()
+
+
+@router.get("/api/colony")
+async def get_colony_stats(request: Request):
+    """Return colony-level statistics."""
+    engine = getattr(request.app.state, "engine", None)
+    if not engine:
+        return {
+            "population": 0,
+            "births": 0,
+            "deaths": 0,
+            "role_distribution": {},
+            "sex_distribution": {},
+            "age_groups": {},
+            "total_resources": {},
+            "factions": [],
+        }
+    stats = engine.colony_stats_collector.collect(
+        engine.agents, engine.faction_manager
+    )
+    return {
+        "population": stats.population,
+        "births": stats.births,
+        "deaths": stats.deaths,
+        "role_distribution": stats.role_distribution,
+        "sex_distribution": stats.sex_distribution,
+        "age_groups": stats.age_groups,
+        "total_resources": stats.total_resources,
+        "factions": stats.factions,
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.core.config import settings
 from app.db.database import engine, Base, async_session_maker
 from app.db import models  # noqa: F401 — registers ORM models with Base.metadata
 from app.api.ws import router as ws_router, manager as ws_manager
+from app.api.colony import router as colony_router
 from app.simulation.world import World
 from app.simulation.agent import Agent
 from app.simulation.engine import SimulationEngine
@@ -82,6 +83,7 @@ app = FastAPI(
 )
 
 app.include_router(ws_router)
+app.include_router(colony_router)
 
 
 @app.get("/health")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -27,6 +27,11 @@ class AgentState(BaseModel):
     speed: int = 50
     system_prompt: str = ""
     monologue_history: list[str] = []
+    relationships: dict[str, dict] = {}
+    knowledge: dict[str, dict] = {}
+    is_child: bool = False
+    parent_id: str | None = None
+    faction_id: str | None = None
 
 
 # --- Simulation Metrics ---
@@ -53,6 +58,7 @@ class TileUpdate(BaseModel):
     y: int
     resource_type: str | None = None
     amount: int = 0
+    subtype: str | None = None
 
 
 # --- Server Message ---
@@ -76,3 +82,5 @@ class WorldSnapshot(BaseModel):
     removed_agents: list[str] = []
     metrics: SimulationMetrics = SimulationMetrics()
     events: list[SimEvent] = []
+    factions: list[dict] = []
+    colony_stats: dict | None = None

--- a/backend/app/simulation/__init__.py
+++ b/backend/app/simulation/__init__.py
@@ -10,6 +10,9 @@ from app.simulation.event_queue import (
 )
 from app.simulation.engine import SimulationEngine
 from app.simulation.snapshot import WorldSnapshotBuilder
+from app.simulation.conversation import Message, ConversationManager
+from app.simulation.faction import Faction, FactionSummary, FactionManager
+from app.simulation.colony import ColonyStats, ColonyStatsCollector
 
 __all__ = [
     "Agent",
@@ -23,4 +26,11 @@ __all__ = [
     "create_death_event",
     "WorldSnapshotBuilder",
     "SimulationEngine",
+    "Message",
+    "ConversationManager",
+    "Faction",
+    "FactionSummary",
+    "FactionManager",
+    "ColonyStats",
+    "ColonyStatsCollector",
 ]

--- a/backend/app/simulation/actions.py
+++ b/backend/app/simulation/actions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from app.simulation.agent import Agent
 from app.simulation.world import World
@@ -18,6 +18,9 @@ class ActionType(str, Enum):
     GATHER = "gather"
     REST = "rest"
     REPRODUCE = "reproduce"
+    TRADE = "trade"
+    SOCIALIZE = "socialize"
+    FEED_CHILD = "feed_child"
 
 
 @dataclass
@@ -26,11 +29,11 @@ class ActionResult:
     events: list[dict] = field(default_factory=list)
     interrupted: bool = False
     state_changes: dict[str, Any] = field(default_factory=dict)
+    action_type: ActionType | None = None
+    action_summary: str = ""
 
 
-ActionHandler = Callable[
-    [Agent, World, Optional[tuple[int, int]], Optional[dict]], ActionResult
-]
+ActionHandler = Callable[..., ActionResult]
 
 
 # ---------------------------------------------------------------------------
@@ -105,11 +108,15 @@ def handle_move(
         agent.target_position = None
         return ActionResult(
             success=True,
+            action_type=ActionType.MOVE,
+            action_summary=f"position:{agent.position}",
             state_changes={"position": agent.position},
         )
 
     return ActionResult(
         success=True,
+        action_type=ActionType.MOVE,
+        action_summary=f"position:{agent.position}",
         state_changes={"position": agent.position},
     )
 
@@ -132,12 +139,16 @@ def handle_chop(
             world.set_tile(x, y, tile)
             return ActionResult(
                 success=True,
+                action_type=ActionType.CHOP,
+                action_summary="wood:+1",
                 events=[{"type": "chop", "resource": "tree", "amount": 1}],
                 state_changes={"inventory": dict(agent.inventory)},
             )
 
     return ActionResult(
         success=False,
+        action_type=ActionType.CHOP,
+        action_summary="chop_failed: no tree nearby",
         events=[{"type": "chop_failed", "reason": "no tree nearby"}],
     )
 
@@ -149,17 +160,28 @@ def handle_drink(
     step: dict | None = None,
 ) -> ActionResult:
     """Drink from a nearby water source, reducing thirst to 0 (fully hydrated)."""
+    if agent.is_child:
+        return ActionResult(
+            success=False,
+            action_type=ActionType.DRINK,
+            action_summary="drink_failed: children cannot drink independently",
+            events=[{"type": "drink_failed", "reason": "child cannot drink independently"}],
+        )
     for x, y, tile in _tiles_on_or_adjacent(agent, world):
         if tile.resource_type == "water":
             agent.thirst = 0.0
             return ActionResult(
                 success=True,
+                action_type=ActionType.DRINK,
+                action_summary="thirst:0",
                 events=[{"type": "drink", "resource": "water"}],
                 state_changes={"thirst": agent.thirst},
             )
 
     return ActionResult(
         success=False,
+        action_type=ActionType.DRINK,
+        action_summary="drink_failed: no water nearby",
         events=[{"type": "drink_failed", "reason": "no water nearby"}],
     )
 
@@ -171,17 +193,37 @@ def handle_eat(
     step: dict | None = None,
 ) -> ActionResult:
     """Consume one unit of berries from inventory to reduce hunger."""
+    if agent.is_child:
+        return ActionResult(
+            success=False,
+            action_type=ActionType.EAT,
+            action_summary="eat_failed: children cannot eat independently",
+            events=[{"type": "eat_failed", "reason": "child cannot eat independently"}],
+        )
     if agent.inventory.get("berries", 0) > 0:
         agent.inventory["berries"] -= 1
         agent.hunger = max(0.0, agent.hunger - 20)
+
+        # F2: reveal hidden properties from nearby tile with matching subtype
+        knowledge_learned = ""
+        for x, y, tile in _tiles_on_or_adjacent(agent, world):
+            if tile.resource_type == "berries" and tile.subtype:
+                agent.knowledge[tile.subtype] = dict(tile.hidden_properties)
+                knowledge_learned = f", learned: {tile.subtype} is {tile.hidden_properties}"
+                break
+
         return ActionResult(
             success=True,
+            action_type=ActionType.EAT,
+            action_summary=f"hunger:-20, berries:-1{knowledge_learned}",
             events=[{"type": "eat", "food": "berries"}],
             state_changes={"hunger": agent.hunger, "inventory": dict(agent.inventory)},
         )
 
     return ActionResult(
         success=False,
+        action_type=ActionType.EAT,
+        action_summary="eat_failed: no food",
         events=[{"type": "eat_failed", "reason": "no food"}],
     )
 
@@ -205,12 +247,16 @@ def handle_gather(
             world.set_tile(x, y, tile)
             return ActionResult(
                 success=True,
+                action_type=ActionType.GATHER,
+                action_summary=f"{key}:+1",
                 events=[{"type": "gather", "resource": key, "amount": 1}],
                 state_changes={"inventory": dict(agent.inventory)},
             )
 
     return ActionResult(
         success=False,
+        action_type=ActionType.GATHER,
+        action_summary="gather_failed: no gatherable resource nearby",
         events=[{"type": "gather_failed", "reason": "no gatherable resource nearby"}],
     )
 
@@ -225,6 +271,8 @@ def handle_rest(
     agent.energy = min(100.0, agent.energy + 10)
     return ActionResult(
         success=True,
+        action_type=ActionType.REST,
+        action_summary="energy:+10",
         events=[{"type": "rest", "energy_gained": 10}],
         state_changes={"energy": agent.energy},
     )
@@ -237,12 +285,132 @@ def handle_reproduce(
     step: dict | None = None,
 ) -> ActionResult:
     """Stub — actual reproduction logic is in SimulationEngine."""
-    return ActionResult(success=True, events=[{"type": "reproduce"}])
+    return ActionResult(
+        success=True,
+        action_type=ActionType.REPRODUCE,
+        action_summary="reproduced",
+        events=[{"type": "reproduce"}],
+    )
 
 
 # ---------------------------------------------------------------------------
 # Registry & metadata
 # ---------------------------------------------------------------------------
+
+def handle_trade(
+    agent: Agent,
+    world: World,
+    target: tuple[int, int] | None = None,
+    step: dict | None = None,
+) -> ActionResult:
+    """Validate trade offer and enqueue proposal in target's conversation queue."""
+    if step is None:
+        return ActionResult(
+            success=False,
+            action_type=ActionType.TRADE,
+            action_summary="trade_failed: no trade step provided",
+            events=[{"type": "trade_failed", "reason": "no trade step"}],
+        )
+
+    offer = step.get("offer", {})
+    request = step.get("request", {})
+
+    # Validate proposer has offer resources
+    for res, qty in offer.items():
+        if agent.inventory.get(res, 0) < qty:
+            return ActionResult(
+                success=False,
+                action_type=ActionType.TRADE,
+                action_summary=f"trade_failed: insufficient {res}",
+                events=[{"type": "trade_failed", "reason": f"insufficient {res}"}],
+            )
+
+    return ActionResult(
+        success=True,
+        action_type=ActionType.TRADE,
+        action_summary=f"trade proposed: offer={offer}, request={request}",
+        events=[{"type": "trade", "offer": offer, "request": request}],
+    )
+
+
+def handle_socialize(
+    agent: Agent,
+    world: World,
+    target: tuple[int, int] | None = None,
+    step: dict | None = None,
+) -> ActionResult:
+    """Stub — socialization is processed via conversation queue."""
+    return ActionResult(
+        success=True,
+        action_type=ActionType.SOCIALIZE,
+        action_summary="socialized",
+        events=[{"type": "socialize"}],
+    )
+
+
+def handle_feed_child(
+    agent: Agent,
+    world: World,
+    target: tuple[int, int] | None = None,
+    step: dict | None = None,
+    agents: list[Agent] | None = None,
+) -> ActionResult:
+    """Feed a child agent: reduce child's hunger by 30, consume 1 berry from caregiver."""
+    if step is None or not step.get("child_id"):
+        return ActionResult(
+            success=False,
+            action_type=ActionType.FEED_CHILD,
+            action_summary="feed_child_failed: no child_id in step",
+            events=[{"type": "feed_child_failed", "reason": "no child_id"}],
+        )
+
+    child_id = step["child_id"]
+    if not agents:
+        return ActionResult(
+            success=False,
+            action_type=ActionType.FEED_CHILD,
+            action_summary="feed_child_failed: no agents available",
+            events=[{"type": "feed_child_failed", "reason": "no agents"}],
+        )
+
+    child = next((a for a in agents if a.id == child_id), None)
+    if not child:
+        return ActionResult(
+            success=False,
+            action_type=ActionType.FEED_CHILD,
+            action_summary="feed_child_failed: child not found",
+            events=[{"type": "feed_child_failed", "reason": "child not found"}],
+        )
+
+    # Child must be within interaction radius (3 tiles)
+    dist = ((agent.position[0] - child.position[0]) ** 2 + (agent.position[1] - child.position[1]) ** 2) ** 0.5
+    if dist > 3.0:
+        return ActionResult(
+            success=False,
+            action_type=ActionType.FEED_CHILD,
+            action_summary="feed_child_failed: child too far",
+            events=[{"type": "feed_child_failed", "reason": "child too far"}],
+        )
+
+    if agent.inventory.get("berries", 0) <= 0:
+        return ActionResult(
+            success=False,
+            action_type=ActionType.FEED_CHILD,
+            action_summary="feed_child_failed: no berries",
+            events=[{"type": "feed_child_failed", "reason": "no berries"}],
+        )
+
+    agent.inventory["berries"] -= 1
+    child.hunger = max(0.0, child.hunger - 30)
+
+    return ActionResult(
+        success=True,
+        action_type=ActionType.FEED_CHILD,
+        action_summary=f"fed {child.name}: hunger:-30, berries:-1",
+        events=[{"type": "feed_child", "child_id": child_id}],
+        state_changes={"hunger": child.hunger, "inventory": dict(agent.inventory)},
+    )
+
 
 REGISTRY: dict[ActionType, ActionHandler] = {
     ActionType.MOVE: handle_move,
@@ -252,6 +420,9 @@ REGISTRY: dict[ActionType, ActionHandler] = {
     ActionType.GATHER: handle_gather,
     ActionType.REST: handle_rest,
     ActionType.REPRODUCE: handle_reproduce,
+    ActionType.TRADE: handle_trade,
+    ActionType.SOCIALIZE: handle_socialize,
+    ActionType.FEED_CHILD: handle_feed_child,
 }
 
 
@@ -265,6 +436,9 @@ def get_action_duration(action_type: ActionType, agent: Agent, world: World = No
         ActionType.GATHER: max(2, 5 - agent.speed // 20),
         ActionType.REST: max(3, 20 - int(agent.energy) // 5),
         ActionType.REPRODUCE: 10,
+        ActionType.TRADE: 5,
+        ActionType.SOCIALIZE: 3,
+        ActionType.FEED_CHILD: 3,
     }
     return durations[action_type]
 
@@ -277,6 +451,9 @@ ACTION_EMOJIS: dict[ActionType, str] = {
     ActionType.GATHER: "🫐",
     ActionType.REST: "💤",
     ActionType.REPRODUCE: "❤️",
+    ActionType.TRADE: "🤝",
+    ActionType.SOCIALIZE: "💬",
+    ActionType.FEED_CHILD: "🍼",
 }
 
 

--- a/backend/app/simulation/agent.py
+++ b/backend/app/simulation/agent.py
@@ -10,6 +10,14 @@ from typing import Any, Optional
 
 
 @dataclass
+class RelationshipData:
+    """Tracks relationship between two agents."""
+    interaction_count: int = 0
+    last_interaction_tick: int = 0
+    score: float = 0.0  # -1.0 to 1.0
+
+
+@dataclass
 class Agent:
     """Simulation agent with physical state, attributes, FSM, and plan tracking."""
 
@@ -66,6 +74,16 @@ class Agent:
     last_thought: str = ""
     system_prompt: str = ""
     monologue_history: list = field(default_factory=list)
+
+    # Social features
+    last_action_result: Optional[Any] = None  # ActionResult from last tick
+    relationships: dict[str, RelationshipData] = field(default_factory=dict)
+    knowledge: dict[str, dict[str, Any]] = field(default_factory=dict)
+    conversation_queue: list = field(default_factory=list)
+    is_child: bool = False
+    parent_id: Optional[str] = None
+    maturity_age: int = 500
+    faction_id: Optional[str] = None
 
 
 class FSM:
@@ -181,9 +199,15 @@ class MockLLMOrchestrator:
 
     def build_prompt(self, agent: Agent, world=None) -> str:
         """Build a mock prompt string from agent state."""
+        from app.simulation.actions import ActionResult
+        lar = agent.last_action_result
+        lar_str = "None (first tick)"
+        if isinstance(lar, ActionResult):
+            lar_str = f"{lar.action_type} success={lar.success} {lar.action_summary}"
         return (
             f"Mock prompt for {agent.name}: "
-            f"hunger={agent.hunger:.0f}, thirst={agent.thirst:.0f}"
+            f"hunger={agent.hunger:.0f}, thirst={agent.thirst:.0f} "
+            f"last_action={lar_str}"
         )
 
     def call_async(self, agent_id: str, prompt: str) -> asyncio.Future:
@@ -244,6 +268,7 @@ class MockLLMOrchestrator:
 
 __all__ = [
     "Agent",
+    "RelationshipData",
     "FSM",
     "AgentFactory",
     "MockLLMOrchestrator",

--- a/backend/app/simulation/colony.py
+++ b/backend/app/simulation/colony.py
@@ -1,0 +1,86 @@
+"""Colony statistics collector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.simulation.agent import Agent
+
+
+@dataclass
+class ColonyStats:
+    population: int
+    births: int
+    deaths: int
+    role_distribution: dict[str, int]
+    sex_distribution: dict[str, int]
+    age_groups: dict[str, int]
+    total_resources: dict[str, int]
+    factions: list[dict]
+
+
+class ColonyStatsCollector:
+    def __init__(self) -> None:
+        self.births = 0
+        self.deaths = 0
+
+    def record_birth(self) -> None:
+        self.births += 1
+
+    def record_death(self) -> None:
+        self.deaths += 1
+
+    def collect(
+        self, agents: list[Agent], faction_manager=None
+    ) -> ColonyStats:
+        role_distribution: dict[str, int] = {}
+        sex_distribution: dict[str, int] = {}
+        age_groups: dict[str, int] = {"child": 0, "adult": 0, "elder": 0}
+        total_resources: dict[str, int] = {}
+
+        for agent in agents:
+            role_distribution[agent.role] = role_distribution.get(agent.role, 0) + 1
+            sex_distribution[agent.sex] = sex_distribution.get(agent.sex, 0) + 1
+
+            if agent.is_child:
+                age_groups["child"] += 1
+            elif agent.age > agent.max_age * 0.7:
+                age_groups["elder"] += 1
+            else:
+                age_groups["adult"] += 1
+
+            for res, qty in agent.inventory.items():
+                total_resources[res] = total_resources.get(res, 0) + qty
+
+        # Include faction shared_resources in total
+        if faction_manager:
+            for faction in faction_manager.get_all().values():
+                for res, qty in faction.shared_resources.items():
+                    total_resources[res] = total_resources.get(res, 0) + qty
+
+        factions = []
+        if faction_manager:
+            factions = [
+                {
+                    "id": f.id,
+                    "name": f.name,
+                    "color": f.color,
+                    "member_count": f.member_count,
+                    "shared_resources": f.shared_resources,
+                }
+                for f in faction_manager.list_all()
+            ]
+
+        return ColonyStats(
+            population=len(agents),
+            births=self.births,
+            deaths=self.deaths,
+            role_distribution=role_distribution,
+            sex_distribution=sex_distribution,
+            age_groups=age_groups,
+            total_resources=total_resources,
+            factions=factions,
+        )
+
+
+__all__ = ["ColonyStats", "ColonyStatsCollector"]

--- a/backend/app/simulation/conversation.py
+++ b/backend/app/simulation/conversation.py
@@ -1,0 +1,150 @@
+"""Conversation system: messages and encounter detection."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from app.simulation.agent import Agent
+from app.simulation.event_queue import SimEvent
+
+
+@dataclass
+class Message:
+    sender_id: str
+    content: dict  # structured: {"type": "greeting"|"share_knowledge"|"trade_proposal"|...}
+    tick: int
+
+
+class ConversationManager:
+    max_pairs_per_tick: int = 5
+    max_queue_size: int = 50
+
+    def __init__(self) -> None:
+        self._pending_pairs: list[tuple[str, str]] = []
+
+    def _enqueue_message(self, agent: Agent, message: Message) -> None:
+        """Add message to agent's queue, respecting max size (FIFO discard)."""
+        agent.conversation_queue.append(message)
+        while len(agent.conversation_queue) > self.max_queue_size:
+            agent.conversation_queue.pop(0)
+
+    def detect_encounters(
+        self, agents: list[Agent], radius: float, tick: int
+    ) -> list[SimEvent]:
+        """Find nearby agent pairs and enqueue greeting messages.
+
+        Returns list of socialize SimEvents.
+        """
+        events: list[SimEvent] = []
+        # First, add any deferred pairs from previous ticks
+        pairs_to_process = list(self._pending_pairs)
+        self._pending_pairs = []
+
+        # Find new pairs
+        new_pairs: list[tuple[str, str]] = []
+        for i, a1 in enumerate(agents):
+            for a2 in agents[i + 1 :]:
+                dist = math.hypot(
+                    a1.position[0] - a2.position[0],
+                    a1.position[1] - a2.position[1],
+                )
+                if dist <= radius:
+                    new_pairs.append((a1.id, a2.id))
+
+        pairs_to_process.extend(new_pairs)
+
+        # Process up to max_pairs_per_tick
+        processed = 0
+        for a1_id, a2_id in pairs_to_process:
+            if processed >= self.max_pairs_per_tick:
+                self._pending_pairs.append((a1_id, a2_id))
+                continue
+            a1 = next((a for a in agents if a.id == a1_id), None)
+            a2 = next((a for a in agents if a.id == a2_id), None)
+            if a1 and a2:
+                self._enqueue_message(
+                    a1,
+                    Message(
+                        sender_id=a2.id,
+                        content={"type": "greeting", "agent_name": a2.name},
+                        tick=tick,
+                    ),
+                )
+                self._enqueue_message(
+                    a2,
+                    Message(
+                        sender_id=a1.id,
+                        content={"type": "greeting", "agent_name": a1.name},
+                        tick=tick,
+                    ),
+                )
+
+                # F2+F6: share knowledge if one knows something the other doesn't
+                for sharer, receiver in [(a1, a2), (a2, a1)]:
+                    for subtype, props in sharer.knowledge.items():
+                        if subtype not in receiver.knowledge:
+                            self._enqueue_message(
+                                receiver,
+                                Message(
+                                    sender_id=sharer.id,
+                                    content={
+                                        "type": "share_knowledge",
+                                        "subtype": subtype,
+                                        "properties": dict(props),
+                                    },
+                                    tick=tick,
+                                ),
+                            )
+                            # Knowledge is applied when receiver processes conversation_queue,
+                            # not directly here.
+                            events.append(
+                                SimEvent(
+                                    event_id=f"knowledge_shared_{tick}_{sharer.id}_{receiver.id}",
+                                    type="knowledge_shared",
+                                    severity="info",
+                                    description=f"{sharer.name} shared knowledge about {subtype} with {receiver.name}",
+                                    agent_ids=[sharer.id, receiver.id],
+                                    tick=tick,
+                                )
+                            )
+                            break  # share only one per encounter
+
+                events.append(
+                    SimEvent(
+                        event_id=f"socialize_{tick}_{a1_id}_{a2_id}",
+                        type="socialize",
+                        severity="info",
+                        description=f"{a1.name} and {a2.name} greeted each other",
+                        agent_ids=[a1_id, a2_id],
+                        tick=tick,
+                        position=(
+                            (a1.position[0] + a2.position[0]) / 2,
+                            (a1.position[1] + a2.position[1]) / 2,
+                        ),
+                    )
+                )
+                processed += 1
+
+        return events
+
+    def process_next_pair(
+        self, agent_a: Agent, agent_b: Agent, tick: int
+    ) -> tuple[Message, Message] | None:
+        """Process a single encounter pair (used for manual/testing)."""
+        msg_a = Message(
+            sender_id=agent_b.id,
+            content={"type": "greeting", "agent_name": agent_b.name},
+            tick=tick,
+        )
+        msg_b = Message(
+            sender_id=agent_a.id,
+            content={"type": "greeting", "agent_name": agent_a.name},
+            tick=tick,
+        )
+        self._enqueue_message(agent_a, msg_a)
+        self._enqueue_message(agent_b, msg_b)
+        return (msg_a, msg_b)
+
+
+__all__ = ["Message", "ConversationManager"]

--- a/backend/app/simulation/engine.py
+++ b/backend/app/simulation/engine.py
@@ -10,7 +10,7 @@ import uuid
 from typing import Optional
 
 from app.core.config import settings
-from app.simulation.agent import Agent, FSM
+from app.simulation.agent import Agent, FSM, RelationshipData
 from app.simulation.actions import (
     ActionType,
     REGISTRY,
@@ -25,6 +25,9 @@ from app.simulation.event_queue import (
 )
 from app.simulation.snapshot import WorldSnapshotBuilder
 from app.simulation.world import World
+from app.simulation.conversation import ConversationManager
+from app.simulation.faction import FactionManager
+from app.simulation.colony import ColonyStatsCollector
 
 logger = logging.getLogger("evociv.engine")
 logger.setLevel(logging.INFO)
@@ -39,6 +42,8 @@ CRITICAL_LLM_TRIGGER = 85  # only LLM trigger on critical (for higher-level plan
 INTERACTION_RADIUS = 3.0  # tiles
 REPRODUCTION_COOLDOWN = 500  # ticks between reproductions
 MAX_POPULATION = 20
+INTERACTION_THRESHOLD = 5
+DECAY_INTERVAL = 100
 
 
 class SimulationEngine:
@@ -64,6 +69,9 @@ class SimulationEngine:
         # Subsystems
         self.fsms = {agent.id: FSM() for agent in agents}  # One FSM per agent
         self.event_queue = EventQueue()
+        self.conversation_manager = ConversationManager()
+        self.faction_manager = FactionManager()
+        self.colony_stats_collector = ColonyStatsCollector()
 
         # LLM orchestrator: use injected one, or create mock as fallback
         if llm_orchestrator is not None:
@@ -125,9 +133,22 @@ class SimulationEngine:
 
     def add_agent(self, agent: Agent) -> str:
         """Add a new agent to the simulation. Returns the agent ID."""
+        # Assign to a faction if not already assigned (before append so index is correct)
+        if not agent.faction_id:
+            factions = self.faction_manager.list_all()
+            if factions:
+                # Distribute round-robin
+                idx = len(self.agents) % len(factions)
+                faction = factions[idx]
+                agent.faction_id = faction.id
+                self.faction_manager.join(agent.id, faction.id)
         self.agents.append(agent)
         self.fsms[agent.id] = FSM()
         self.builder.mark_agent_dirty(agent.id)
+        # Inject faction_manager into LLM orchestrator if needed
+        if hasattr(self.llm, "faction_manager") and getattr(self.llm, "faction_manager", None) is None:
+            self.llm.faction_manager = self.faction_manager
+        self.colony_stats_collector.record_birth()
         logger.info(f"Agent {agent.name} ({agent.id}) added to simulation")
         return agent.id
 
@@ -174,7 +195,30 @@ class SimulationEngine:
             except Exception as e:
                 logger.error(f"FSM error for {agent.name}: {e}")
 
-        # 3. Process event queue (events pushed during FSM run)
+        # 3. Process social interactions (conversations)
+        social_events = self.conversation_manager.detect_encounters(
+            self.agents, INTERACTION_RADIUS, tick
+        )
+        for ev in social_events:
+            self.event_queue.push(
+                ev.type,
+                ev.description,
+                ev.severity,
+                ev.agent_ids,
+                tick,
+                ev.position,
+            )
+            # F6: update relationships for socialize and knowledge share events
+            if ev.type in ("socialize", "knowledge_shared") and len(ev.agent_ids) == 2:
+                a1 = next((a for a in self.agents if a.id == ev.agent_ids[0]), None)
+                a2 = next((a for a in self.agents if a.id == ev.agent_ids[1]), None)
+                if a1 and a2:
+                    self._update_relationship(a1, a2, tick, score_delta=0.1)
+
+        # 3b. Process pending trade proposals
+        await self._process_trade_proposals(tick)
+
+        # 4. Process event queue (events pushed during FSM run)
         events = self.event_queue.drain()
 
         # 4. Poll LLM futures
@@ -216,7 +260,18 @@ class SimulationEngine:
         all_events = events + self.event_queue.drain()
 
         # 9. Build and broadcast snapshot
-        snapshot = self.builder.build_delta(tick, all_events)
+        colony_stats = self.colony_stats_collector.collect(
+            self.agents, self.faction_manager
+        )
+        colony_stats_dict = {
+            "population": colony_stats.population,
+            "births": colony_stats.births,
+            "deaths": colony_stats.deaths,
+            "total_resources": colony_stats.total_resources,
+        }
+        snapshot = self.builder.build_delta(
+            tick, all_events, faction_manager=self.faction_manager, colony_stats=colony_stats_dict
+        )
         if self.ws_manager:
             try:
                 await self.ws_manager.broadcast(
@@ -229,7 +284,9 @@ class SimulationEngine:
                 logger.error(f"Broadcast error: {e}")
 
         # 10. Store full snapshot for new WS clients
-        self._latest_full_snapshot = self.builder.build(tick, all_events).model_dump()
+        self._latest_full_snapshot = self.builder.build(
+            tick, all_events, faction_manager=self.faction_manager, colony_stats=colony_stats_dict
+        ).model_dump()
         if self.ws_manager:
             self.ws_manager.latest_snapshot = self._latest_full_snapshot
 
@@ -242,6 +299,108 @@ class SimulationEngine:
     # ------------------------------------------------------------------
     # Needs & death
     # ------------------------------------------------------------------
+
+    def _update_relationship(
+        self, agent_a: Agent, agent_b: Agent, tick: int, score_delta: float = 0.1
+    ) -> None:
+        """Update relationship data for two interacting agents."""
+        if agent_b.id not in agent_a.relationships:
+            agent_a.relationships[agent_b.id] = RelationshipData()
+        if agent_a.id not in agent_b.relationships:
+            agent_b.relationships[agent_a.id] = RelationshipData()
+
+        agent_a.relationships[agent_b.id].interaction_count += 1
+        agent_a.relationships[agent_b.id].last_interaction_tick = tick
+        agent_a.relationships[agent_b.id].score = max(
+            -1.0, min(1.0, agent_a.relationships[agent_b.id].score + score_delta)
+        )
+
+        agent_b.relationships[agent_a.id].interaction_count += 1
+        agent_b.relationships[agent_a.id].last_interaction_tick = tick
+        agent_b.relationships[agent_a.id].score = max(
+            -1.0, min(1.0, agent_b.relationships[agent_a.id].score + score_delta)
+        )
+
+    async def _evaluate_trade_proposal(self, agent: Agent, proposal: dict) -> bool:
+        """Evaluate a trade proposal via LLM. Returns True for accept, False for reject."""
+        # Build a trade-specific prompt
+        prompt = (
+            f"Trade proposal from {proposal.get('from')}: "
+            f"they offer {proposal.get('offer', {})} and request {proposal.get('request', {})}. "
+            f"Your current inventory: {agent.inventory}. "
+            f"Reply with ONLY a JSON object: {{'decision': 'accept' or 'reject'}}"
+        )
+        try:
+            future = self.llm.call_async(agent.id, prompt)
+            result = await asyncio.wait_for(future, timeout=0.5)
+            if result.get("success") and result.get("data"):
+                decision = result.get("data", {}).get("decision", "reject")
+                return decision == "accept"
+        except asyncio.TimeoutError:
+            pass
+        except Exception:
+            pass
+        # Fallback: deterministic evaluation based on resource availability
+        request = proposal.get("request", {})
+        return all(agent.inventory.get(res, 0) >= qty for res, qty in request.items())
+
+    async def _process_trade_proposals(self, tick: int) -> None:
+        """Process pending trade proposals in agents' conversation queues."""
+        proposals: list[tuple[Agent, dict]] = []
+        for agent in self.agents:
+            for msg in list(agent.conversation_queue):
+                if msg.content.get("type") != "trade_proposal":
+                    continue
+                # Skip proposals created in the current tick — let the target see them first
+                if msg.tick >= tick:
+                    continue
+                # Remove the proposal from queue so it's processed once
+                agent.conversation_queue.remove(msg)
+                proposals.append((agent, msg.content))
+
+        async def _process_one(agent: Agent, proposal: dict) -> None:
+            proposer_id = proposal.get("from")
+            offer = proposal.get("offer", {})
+            request = proposal.get("request", {})
+            proposer = next((a for a in self.agents if a.id == proposer_id), None)
+            if not proposer:
+                return
+
+            accepted = await self._evaluate_trade_proposal(agent, proposal)
+
+            if accepted:
+                # Verify both still have resources (race condition check)
+                proposer_has = all(proposer.inventory.get(res, 0) >= qty for res, qty in offer.items())
+                target_has = all(agent.inventory.get(res, 0) >= qty for res, qty in request.items())
+                if proposer_has and target_has:
+                    # Atomic swap
+                    for res, qty in offer.items():
+                        proposer.inventory[res] = proposer.inventory.get(res, 0) - qty
+                        agent.inventory[res] = agent.inventory.get(res, 0) + qty
+                    for res, qty in request.items():
+                        agent.inventory[res] = agent.inventory.get(res, 0) - qty
+                        proposer.inventory[res] = proposer.inventory.get(res, 0) + qty
+                    self._update_relationship(proposer, agent, tick, score_delta=0.2)
+                    self.event_queue.push(
+                        "trade",
+                        f"{proposer.name} traded {offer} for {request} with {agent.name}",
+                        "info",
+                        [proposer.id, agent.id],
+                        tick,
+                    )
+                    return
+
+            # Rejected or insufficient resources
+            self.event_queue.push(
+                "trade",
+                f"{agent.name} rejected trade from {proposer.name}: insufficient resources",
+                "info",
+                [proposer.id, agent.id],
+                tick,
+            )
+
+        if proposals:
+            await asyncio.gather(*[_process_one(agent, proposal) for agent, proposal in proposals])
 
     async def _process_needs(self, tick: int) -> None:
         """Decay hunger/thirst/energy and check for deaths."""
@@ -266,25 +425,82 @@ class SimulationEngine:
             agent.health = max(0.0, min(100.0, agent.health))
             agent.energy = max(0.0, min(100.0, agent.energy))
 
+            # Relationship decay
+            for other_id, rel in list(agent.relationships.items()):
+                if tick - rel.last_interaction_tick > DECAY_INTERVAL:
+                    rel.interaction_count = max(0, rel.interaction_count - 1)
+                    rel.score = max(-1.0, min(1.0, rel.score - 0.01))
+                    rel.last_interaction_tick = tick
+
+            # Child maturity
+            if agent.is_child and agent.age >= agent.maturity_age:
+                agent.is_child = False
+                agent.parent_id = None
+                self.event_queue.push(
+                    "maturity",
+                    f"{agent.name} has reached maturity",
+                    "info",
+                    [agent.id],
+                    tick,
+                )
+
             if agent.health <= 0:
-                dead_agents.append(agent)
+                cause = "thirst" if agent.thirst >= 100 else "starvation"
+                dead_agents.append((agent, cause))
                 continue
 
             # Death by old age
             if agent.age >= agent.max_age:
-                dead_agents.append(agent)
+                dead_agents.append((agent, "old_age"))
                 continue
 
-        for agent in dead_agents:
-            death_event = create_death_event(agent, tick)
+        for agent, cause in dead_agents:
+            self.colony_stats_collector.record_death()
+            # F4: transfer inventory to faction
+            self.faction_manager.transfer_inventory_on_death(agent)
+
+            # F3: orphan adoption
+            for child in list(self.agents):
+                if child.is_child and child.parent_id == agent.id:
+                    # Find nearest adult
+                    nearest = None
+                    nearest_dist = float("inf")
+                    for other in self.agents:
+                        if other.id == agent.id or other.id == child.id:
+                            continue
+                        if other.is_child:
+                            continue
+                        dist = math.hypot(
+                            other.position[0] - child.position[0],
+                            other.position[1] - child.position[1],
+                        )
+                        if dist < nearest_dist and dist <= INTERACTION_RADIUS:
+                            nearest = other
+                            nearest_dist = dist
+                    if nearest:
+                        child.parent_id = nearest.id
+                        self.event_queue.push(
+                            "adoption",
+                            f"{nearest.name} adopted {child.name} after {agent.name} died",
+                            "info",
+                            [nearest.id, child.id],
+                            tick,
+                        )
+                    else:
+                        # No adopter — accelerate decay
+                        child.health -= 2.0
+
+            death_event = create_death_event(agent, tick, cause=cause)
             self.event_queue.push(
                 death_event.type,
                 death_event.description,
                 death_event.severity,
                 death_event.agent_ids,
                 tick,
+                metadata=death_event.metadata,
             )
             self.agents.remove(agent)
+            del self.fsms[agent.id]
             self.builder.mark_agent_removed(agent.id)
             logger.warning(f"{agent.name} died at tick {tick}")
 
@@ -321,9 +537,13 @@ class SimulationEngine:
         fsm.transition_to("evaluate")
 
     def _find_reproduction_partner(self, agent: Agent) -> Optional[Agent]:
-        """Find a compatible reproduction partner nearby (lax thresholds)."""
+        """Find a compatible reproduction partner nearby (gated by interactions)."""
+        if agent.is_child:
+            return None
         for other in self.agents:
             if other.id == agent.id:
+                continue
+            if other.is_child:
                 continue
             if other.sex == agent.sex:
                 continue
@@ -332,6 +552,10 @@ class SimulationEngine:
             if getattr(other, '_is_reproducing', False):
                 continue
             if getattr(other, 'age', 0) < 100:  # too young
+                continue
+            # F8: require interaction threshold
+            rel = agent.relationships.get(other.id)
+            if not rel or rel.interaction_count < INTERACTION_THRESHOLD:
                 continue
             dist = math.hypot(
                 agent.position[0] - other.position[0],
@@ -344,18 +568,37 @@ class SimulationEngine:
     def _create_offspring(self, parent1: Agent, parent2: Agent, tick: int) -> Agent:
         """Create a new Agent as offspring of two parents."""
         import random
-        avg_x = (parent1.position[0] + parent2.position[0]) / 2 + random.uniform(-1, 1)
-        avg_y = (parent1.position[1] + parent2.position[1]) / 2 + random.uniform(-1, 1)
-        avg_x = max(1, min(self.world.width - 2, avg_x))
-        avg_y = max(1, min(self.world.height - 2, avg_y))
+
+        # Spawn adjacent to parent1 (search radius 2)
+        child_pos = (parent1.position[0], parent1.position[1])
+        for radius in range(1, 3):
+            found = False
+            for dx, dy in [(0, 0), (1, 0), (-1, 0), (0, 1), (0, -1), (1, 1), (-1, 1), (1, -1), (-1, -1)]:
+                if radius == 1 and (dx, dy) == (0, 0):
+                    continue
+                nx, ny = int(parent1.position[0]) + dx * radius, int(parent1.position[1]) + dy * radius
+                if (
+                    0 <= nx < self.world.width
+                    and 0 <= ny < self.world.height
+                    and not self._is_tile_occupied(nx, ny)
+                ):
+                    child_pos = (float(nx), float(ny))
+                    found = True
+                    break
+            if found:
+                break
 
         def inherit(a1_val, a2_val):
             return max(0, min(100, (a1_val + a2_val) // 2 + random.randint(-10, 10)))
 
+        # F3: derive stats from parent with ±15 random offset
+        def inherit_with_offset(parent_val):
+            return max(0, min(100, parent_val + random.randint(-15, 15)))
+
         child = Agent(
             id=f"agent_{uuid.uuid4().hex[:6]}",
             name=self._generate_agent_name(),
-            position=(avg_x, avg_y),
+            position=child_pos,
             role=random.choice([parent1.role, parent2.role]),
             strength=inherit(parent1.strength, parent2.strength),
             intelligence=inherit(parent1.intelligence, parent2.intelligence),
@@ -364,6 +607,9 @@ class SimulationEngine:
             sex=random.choice(["male", "female"]),
             age=0,
             max_age=random.randint(2000, 5000),
+            is_child=True,
+            parent_id=parent1.id,
+            maturity_age=random.randint(300, 700),
         )
         return child
 
@@ -378,9 +624,10 @@ class SimulationEngine:
         """Check needs and decide next state.
         
         Priority order:
+        0. Feed child if caregiver and child is critical
         1. Eat from inventory if hungry
         2. Drink if thirsty and at water
-        3. Gather food if hungry and at source
+        3. Gather food if hungry and at food source
         4. Rest if energy is low
         5. Move toward food/water if critical
         6. Reproduce if conditions met (lax thresholds)
@@ -389,6 +636,55 @@ class SimulationEngine:
         nearby = self.world.get_nearby_resources(agent.position, radius=8)
         food_nearby = [r for r in nearby if r[2] in ("berries", "tree")]
         water_nearby = [r for r in nearby if r[2] == "water"]
+
+        # ── 0. Feed child if caregiver and child is critical ──
+        if not agent.is_child and agent.inventory.get("berries", 0) > 0:
+            for child in self.agents:
+                if child.is_child and child.parent_id == agent.id:
+                    dist = math.hypot(
+                        agent.position[0] - child.position[0],
+                        agent.position[1] - child.position[1],
+                    )
+                    if dist <= INTERACTION_RADIUS:
+                        if child.hunger > 70:
+                            agent.current_action = "feed_child"
+                            agent.current_action_emoji = "🍼"
+                            agent.action_duration = get_action_duration(ActionType.FEED_CHILD, agent)
+                            agent.action_progress = 0.0
+                            # Store child id in active plan step so handler can find it
+                            agent.active_plan = {
+                                "steps": [{"action": "feed_child", "target": None, "child_id": child.id}]
+                            }
+                            agent.plan_step_index = 0
+                            fsm.transition_to("executing")
+                            return
+                        elif child.thirst > 70:
+                            # Child is thirsty — seek water to give drink
+                            nearby = self.world.get_nearby_resources(agent.position, radius=8)
+                            water_nearby = [r for r in nearby if r[2] == "water"]
+                            if water_nearby:
+                                target = (water_nearby[0][0], water_nearby[0][1])
+                                agent.current_action = "seeking water"
+                                agent.current_action_emoji = "🍼"
+                                agent.target_position = (float(target[0]), float(target[1]))
+                                agent.move_path = self.world.find_path(
+                                    (int(agent.position[0]), int(agent.position[1])), target
+                                )
+                                agent.move_progress = 0.0
+                                fsm.transition_to("moving")
+                                return
+                    else:
+                        # Move toward child
+                        target = (int(child.position[0]), int(child.position[1]))
+                        agent.current_action = "seeking child"
+                        agent.current_action_emoji = "🍼"
+                        agent.target_position = (float(target[0]), float(target[1]))
+                        agent.move_path = self.world.find_path(
+                            (int(agent.position[0]), int(agent.position[1])), target
+                        )
+                        agent.move_progress = 0.0
+                        fsm.transition_to("moving")
+                        return
 
         # ── 1. Eat from inventory if hungry ──
         if agent.hunger > CRITICAL_HUNGER and agent.inventory.get("berries", 0) > 0:
@@ -480,6 +776,11 @@ class SimulationEngine:
                     agent._reproduce_partner_id = partner.id
                     partner._reproduce_partner_id = agent.id
                     fsm.transition_to("executing")
+                    fsm_partner = self.fsms[partner.id]
+                    if fsm_partner.current_state == "idle":
+                        fsm_partner.transition_to("evaluate")
+                    if fsm_partner.current_state != "executing":
+                        fsm_partner.transition_to("executing")
                     return
 
         # Needs met → try LLM for higher-level planning
@@ -561,8 +862,7 @@ class SimulationEngine:
                 # Can't move anywhere — wait a tick
                 self.builder.mark_agent_dirty(agent.id)
                 return  # stay in moving, try again next tick
-            # Even if we nudged, we still consumed the path step when we retry
-            agent.move_path.pop(0)
+            # Nudged to adjacent tile; don't consume the path step yet
         else:
             # Tile is free — advance normally
             agent.move_path.pop(0)
@@ -616,7 +916,34 @@ class SimulationEngine:
                         int(agent.target_position[0]),
                         int(agent.target_position[1]),
                     )
-                result = handler(agent, self.world, target, None)
+                # For trade/feed_child, pass the plan step so extra params are available
+                step = None
+                if agent.active_plan and action_type in (ActionType.TRADE, ActionType.FEED_CHILD):
+                    step = agent.active_plan["steps"][agent.plan_step_index]
+                if action_type == ActionType.FEED_CHILD:
+                    result = handler(agent, self.world, target, step, self.agents)
+                else:
+                    result = handler(agent, self.world, target, step)
+                agent.last_action_result = result
+
+                # F5: enqueue trade proposal in target's conversation queue
+                if action_type == ActionType.TRADE and result.success and step:
+                    target_id = step.get("target")
+                    target_agent = next((a for a in self.agents if a.id == target_id), None)
+                    if target_agent:
+                        from app.simulation.conversation import Message
+                        target_agent.conversation_queue.append(
+                            Message(
+                                sender_id=agent.id,
+                                content={
+                                    "type": "trade_proposal",
+                                    "from": agent.id,
+                                    "offer": step.get("offer", {}),
+                                    "request": step.get("request", {}),
+                                },
+                                tick=tick,
+                            )
+                        )
 
                 if result.interrupted or not result.success:
                     fsm.transition_to("evaluate")
@@ -671,6 +998,8 @@ class SimulationEngine:
             return
 
         prompt = self.llm.build_prompt(agent, self.world)
+        # F1: consume last_action_result after prompt build to prevent stale accumulation
+        agent.last_action_result = None
         agent.llm_future = self.llm.call_async(agent.id, prompt)
         agent.llm_call_pending = True
         agent._last_llm_tick = tick
@@ -682,6 +1011,8 @@ class SimulationEngine:
         """Wait for LLM response while acting on instinct."""
         # If no future is set (cooldown or first trigger misfire), go back to evaluate
         if not agent.llm_future:
+            # F1: discard stale last_action_result on fallback
+            agent.last_action_result = None
             fsm.transition_to("evaluate")
             return
 

--- a/backend/app/simulation/event_queue.py
+++ b/backend/app/simulation/event_queue.py
@@ -81,7 +81,7 @@ def check_proximity_encounters(
                 a1.position[0] - a2.position[0],
                 a1.position[1] - a2.position[1],
             )
-            if dist < radius:
+            if dist <= radius:
                 events.append(
                     SimEvent(
                         event_id=f"encounter_{uuid.uuid4().hex[:8]}",

--- a/backend/app/simulation/faction.py
+++ b/backend/app/simulation/faction.py
@@ -1,0 +1,111 @@
+"""Faction system: groups, shared resources, and management."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from app.simulation.agent import Agent
+
+
+@dataclass
+class FactionSummary:
+    id: str
+    name: str
+    color: str
+    member_count: int
+    shared_resources: dict[str, int]
+
+
+@dataclass
+class Faction:
+    id: str
+    name: str
+    color: str  # hex, e.g. "#FF0000"
+    member_ids: list[str] = field(default_factory=list)
+    shared_resources: dict[str, int] = field(default_factory=dict)
+
+
+class FactionManager:
+    def __init__(self) -> None:
+        self.factions: dict[str, Faction] = {}
+        self._create_defaults()
+
+    def _create_defaults(self) -> None:
+        """Create default factions if none exist."""
+        if not self.factions:
+            self.create("River Clan", "#00AAFF")
+            self.create("Stone Hold", "#FF8800")
+            self.create("Green Ward", "#44BB44")
+
+    def create(self, name: str, color: str) -> Faction:
+        """Create a new faction."""
+        faction = Faction(
+            id=f"faction_{uuid.uuid4().hex[:6]}",
+            name=name,
+            color=color,
+        )
+        self.factions[faction.id] = faction
+        return faction
+
+    def delete(self, faction_id: str) -> bool:
+        """Delete a faction. Returns True if deleted."""
+        if faction_id in self.factions:
+            del self.factions[faction_id]
+            return True
+        return False
+
+    def join(self, agent_id: str, faction_id: str) -> bool:
+        """Add an agent to a faction."""
+        faction = self.factions.get(faction_id)
+        if not faction:
+            return False
+        if agent_id not in faction.member_ids:
+            faction.member_ids.append(agent_id)
+        return True
+
+    def leave(self, agent_id: str, faction_id: str) -> bool:
+        """Remove an agent from a faction."""
+        faction = self.factions.get(faction_id)
+        if not faction:
+            return False
+        if agent_id in faction.member_ids:
+            faction.member_ids.remove(agent_id)
+        return True
+
+    def list_all(self) -> list[FactionSummary]:
+        """Return summaries of all factions."""
+        return [
+            FactionSummary(
+                id=f.id,
+                name=f.name,
+                color=f.color,
+                member_count=len(f.member_ids),
+                shared_resources=dict(f.shared_resources),
+            )
+            for f in self.factions.values()
+        ]
+
+    def get_faction(self, faction_id: str) -> Faction | None:
+        """Get a faction by ID."""
+        return self.factions.get(faction_id)
+
+    def transfer_inventory_on_death(self, agent: Agent) -> None:
+        """Transfer an agent's inventory to their faction's shared resources."""
+        if not agent.faction_id:
+            return
+        faction = self.factions.get(agent.faction_id)
+        if not faction:
+            return
+        for resource, amount in agent.inventory.items():
+            faction.shared_resources[resource] = (
+                faction.shared_resources.get(resource, 0) + amount
+            )
+        self.leave(agent.id, agent.faction_id)
+
+    def get_all(self) -> dict[str, Faction]:
+        """Return all factions dict."""
+        return dict(self.factions)
+
+
+__all__ = ["Faction", "FactionSummary", "FactionManager"]

--- a/backend/app/simulation/snapshot.py
+++ b/backend/app/simulation/snapshot.py
@@ -55,6 +55,18 @@ class WorldSnapshotBuilder:
             speed=agent.speed,
             system_prompt=agent.system_prompt[:200] if agent.system_prompt else "",
             monologue_history=list(agent.monologue_history[-5:]),
+            relationships={
+                k: {
+                    "interaction_count": v.interaction_count,
+                    "last_interaction_tick": v.last_interaction_tick,
+                    "score": round(v.score, 2),
+                }
+                for k, v in agent.relationships.items()
+            },
+            knowledge=dict(agent.knowledge),
+            is_child=agent.is_child,
+            parent_id=agent.parent_id,
+            faction_id=agent.faction_id,
         )
 
     def _compute_metrics(self) -> SimulationMetrics:
@@ -83,7 +95,9 @@ class WorldSnapshotBuilder:
             for e in engine_events
         ]
 
-    def build(self, tick: int, events: list[EngineEvent] | None = None) -> WorldSnapshot:
+    def build(
+        self, tick: int, events: list[EngineEvent] | None = None, faction_manager=None, colony_stats=None
+    ) -> WorldSnapshot:
         """
         Build a complete snapshot of the simulation state.
         Includes ALL agents (full state) and ALL tiles (those with resources).
@@ -98,6 +112,7 @@ class WorldSnapshotBuilder:
                         x=x, y=y,
                         resource_type=tile.resource_type,
                         amount=int(tile.amount),
+                        subtype=tile.subtype,
                     ))
 
         # All agents (full state)
@@ -105,17 +120,36 @@ class WorldSnapshotBuilder:
         for agent in self.agents:
             agents_dict[agent.id] = self._build_agent_state(agent)
 
+        factions = []
+        if faction_manager:
+            factions = [
+                {
+                    "id": f.id,
+                    "name": f.name,
+                    "color": f.color,
+                    "member_count": f.member_count,
+                    "shared_resources": f.shared_resources,
+                }
+                for f in faction_manager.list_all()
+            ]
+
+        removed = list(self._removed_agents)
+        self._removed_agents.clear()
         return WorldSnapshot(
             tick=tick,
             timestamp=time.time(),
             tiles=tiles,
             agents=agents_dict,
-            removed_agents=list(self._removed_agents),
+            removed_agents=removed,
             metrics=self._compute_metrics(),
             events=self._convert_events(events or []),
+            factions=factions,
+            colony_stats=colony_stats,
         )
 
-    def build_delta(self, tick: int, events: list[EngineEvent] | None = None) -> WorldSnapshot:
+    def build_delta(
+        self, tick: int, events: list[EngineEvent] | None = None, faction_manager=None, colony_stats=None
+    ) -> WorldSnapshot:
         """
         Build a delta snapshot — only changed data since last call.
         - Tiles: only dirty tiles
@@ -131,6 +165,7 @@ class WorldSnapshotBuilder:
                 x=x, y=y,
                 resource_type=tile.resource_type,
                 amount=int(tile.amount),
+                subtype=tile.subtype,
             ))
         self.world.reset_dirty_tiles()
 
@@ -139,9 +174,21 @@ class WorldSnapshotBuilder:
         for agent in self.agents:
             agents_dict[agent.id] = self._build_agent_state(agent)
 
-        # Removed agents (drain)
+        # Removed agents (don't clear here — build() will clear after full snapshot)
         removed = list(self._removed_agents)
-        self._removed_agents.clear()
+
+        factions = []
+        if faction_manager:
+            factions = [
+                {
+                    "id": f.id,
+                    "name": f.name,
+                    "color": f.color,
+                    "member_count": f.member_count,
+                    "shared_resources": f.shared_resources,
+                }
+                for f in faction_manager.list_all()
+            ]
 
         return WorldSnapshot(
             tick=tick,
@@ -151,6 +198,8 @@ class WorldSnapshotBuilder:
             removed_agents=removed,
             metrics=self._compute_metrics(),
             events=self._convert_events(events or []),
+            factions=factions,
+            colony_stats=colony_stats,
         )
 
 

--- a/backend/app/simulation/world.py
+++ b/backend/app/simulation/world.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional
 
@@ -23,6 +23,8 @@ class Tile:
     max_amount: int = 0
     regen_rate: float = 0.0
     blocked: bool = False
+    subtype: Optional[str] = None
+    hidden_properties: dict = field(default_factory=dict)
 
 
 class World:
@@ -126,6 +128,15 @@ class World:
         while placed < count and available:
             x, y = available.pop()
             amount = rng.randint(*amount_range)
+            subtype = None
+            hidden_properties = {}
+            if resource_type == ResourceType.BERRIES:
+                if rng.random() < 0.3:
+                    subtype = "POISONOUS_BERRY"
+                    hidden_properties = {"is_poisonous": True}
+                else:
+                    subtype = "SAFE_BERRY"
+                    hidden_properties = {"is_poisonous": False}
             tile = Tile(
                 x=x,
                 y=y,
@@ -133,6 +144,8 @@ class World:
                 amount=amount,
                 max_amount=amount,
                 regen_rate=regen_rate,
+                subtype=subtype,
+                hidden_properties=hidden_properties,
             )
             self.grid[y][x] = tile
             self.dirty_tiles.add((x, y))

--- a/frontend/src/lib/canvas/entities.ts
+++ b/frontend/src/lib/canvas/entities.ts
@@ -14,6 +14,10 @@ export interface AgentRenderData {
 	thirst: number;
 	/** Name for display */
 	name: string;
+	/** Faction color for border rendering */
+	factionColor: string | null;
+	/** Whether the agent is a child */
+	is_child: boolean;
 }
 
 const ROLE_COLORS: Record<string, string> = {
@@ -56,9 +60,19 @@ export class Entities {
 			this.ctx.fillStyle = 'rgba(0,0,0,0.25)';
 			this.ctx.fill();
 
-			// Body circle
+			// Faction border
+			if (a.factionColor) {
+				this.ctx.beginPath();
+				this.ctx.arc(px, py, RADIUS + 3, 0, Math.PI * 2);
+				this.ctx.strokeStyle = a.factionColor;
+				this.ctx.lineWidth = 3;
+				this.ctx.stroke();
+			}
+
+			// Body circle (children are smaller)
+			const radius = a.is_child ? RADIUS * 0.6 : RADIUS;
 			this.ctx.beginPath();
-			this.ctx.arc(px, py, RADIUS, 0, Math.PI * 2);
+			this.ctx.arc(px, py, radius, 0, Math.PI * 2);
 			this.ctx.fillStyle = color;
 			this.ctx.fill();
 			this.ctx.strokeStyle = 'rgba(0,0,0,0.4)';
@@ -93,6 +107,14 @@ export class Entities {
 	updateFromSnapshot(data: any): void {
 		if (!data?.agents) return;
 
+		// Build factions lookup
+		const factions: Record<string, { color: string }> = {};
+		if (data.factions && Array.isArray(data.factions)) {
+			for (const f of data.factions) {
+				if (f.id) factions[f.id] = f;
+			}
+		}
+
 		// Remove dead agents (explicitly from removed_agents list)
 		if (data.removed_agents) {
 			for (const id of data.removed_agents) {
@@ -123,7 +145,9 @@ export class Entities {
 					emoji: '',
 					hunger: 0,
 					thirst: 0,
-					name: state.name ?? id
+					name: state.name ?? id,
+					factionColor: null,
+					is_child: false
 				};
 				this.agents.set(id, a);
 			}
@@ -134,6 +158,8 @@ export class Entities {
 			a.hunger = state.hunger ?? a.hunger;
 			a.thirst = state.thirst ?? a.thirst;
 			a.name = state.name ?? a.name;
+			a.factionColor = state.faction_id ? (factions[state.faction_id]?.color ?? null) : null;
+			a.is_child = state.is_child ?? false;
 		}
 	}
 

--- a/frontend/src/lib/components/AgentInspector.svelte
+++ b/frontend/src/lib/components/AgentInspector.svelte
@@ -25,7 +25,21 @@
 		last_thought?: string;
 		system_prompt?: string;
 		monologue_history?: string[];
+		relationships?: Record<string, { interaction_count: number; last_interaction_tick: number; score: number }>;
+		faction_id?: string;
+		knowledge?: Record<string, Record<string, unknown>>;
+		is_child?: boolean;
+		parent_id?: string;
+		maturity_age?: number;
 		[key: string]: unknown;
+	}
+
+	interface FactionData {
+		id: string;
+		name: string;
+		color: string;
+		member_count: number;
+		shared_resources: Record<string, number>;
 	}
 
 	let agent = $derived<AgentData | null>(
@@ -33,6 +47,7 @@
 			? (($simulationStore.agents as Record<string, AgentData>)[$uiStore.selectedAgentId] ?? null)
 			: null
 	);
+	let factions = $derived(($simulationStore.factions ?? {}) as Record<string, FactionData>);
 
 	const ITEM_EMOJIS: Record<string, string> = {
 		berries: '🫐',
@@ -161,6 +176,83 @@
 					</ul>
 				{:else}
 					<p class="empty">(no thoughts)</p>
+				{/if}
+			</div>
+		</details>
+
+		<details class="section">
+			<summary>Relationships</summary>
+			<div class="section-body">
+				{#if agent.relationships && Object.keys(agent.relationships).length > 0}
+					{#each Object.entries(agent.relationships) as [otherId, rel] (otherId)}
+						{@const other = ($simulationStore.agents as Record<string, AgentData>)?.[otherId]}
+						<div class="kv-row">
+							<span class="kv-key">{other?.name ?? otherId}</span>
+							<span class="kv-value">count:{rel.interaction_count} score:{rel.score.toFixed(2)}</span>
+						</div>
+					{/each}
+				{:else}
+					<p class="empty">(no relationships yet)</p>
+				{/if}
+			</div>
+		</details>
+
+		<details class="section">
+			<summary>Faction</summary>
+			<div class="section-body">
+				{#if agent.faction_id}
+					{@const faction = factions[agent.faction_id]}
+					<div class="kv-row">
+						<span class="kv-key">Name</span>
+						<span class="kv-value" style="display:flex;align-items:center;gap:6px;">
+							{#if faction}
+								<span style="width:12px;height:12px;border-radius:50%;background:{faction.color};display:inline-block;"></span>
+								{faction.name}
+							{:else}
+								{agent.faction_id}
+							{/if}
+						</span>
+					</div>
+				{:else}
+					<p class="empty">(not in a faction)</p>
+				{/if}
+			</div>
+		</details>
+
+		<details class="section">
+			<summary>Knowledge</summary>
+			<div class="section-body">
+				{#if agent.knowledge && Object.keys(agent.knowledge).length > 0}
+					{#each Object.entries(agent.knowledge) as [k, v] (k)}
+						<div class="kv-row">
+							<span class="kv-key">{k}</span>
+							<span class="kv-value">{JSON.stringify(v)}</span>
+						</div>
+					{/each}
+				{:else}
+					<p class="empty">(no special knowledge)</p>
+				{/if}
+			</div>
+		</details>
+
+		<details class="section">
+			<summary>Child Status</summary>
+			<div class="section-body">
+				{#if agent.is_child}
+					<div class="kv-row">
+						<span class="kv-key">Status</span>
+						<span class="kv-value">Child</span>
+					</div>
+					<div class="kv-row">
+						<span class="kv-key">Parent</span>
+						<span class="kv-value">{agent.parent_id ?? '—'}</span>
+					</div>
+					<div class="kv-row">
+						<span class="kv-key">Maturity</span>
+						<span class="kv-value">{agent.age ?? 0} / {agent.maturity_age ?? 0}</span>
+					</div>
+				{:else}
+					<p class="empty">Adult</p>
 				{/if}
 			</div>
 		</details>

--- a/frontend/src/lib/components/AgentInspector.svelte
+++ b/frontend/src/lib/components/AgentInspector.svelte
@@ -25,7 +25,10 @@
 		last_thought?: string;
 		system_prompt?: string;
 		monologue_history?: string[];
-		relationships?: Record<string, { interaction_count: number; last_interaction_tick: number; score: number }>;
+		relationships?: Record<
+			string,
+			{ interaction_count: number; last_interaction_tick: number; score: number }
+		>;
 		faction_id?: string;
 		knowledge?: Record<string, Record<string, unknown>>;
 		is_child?: boolean;
@@ -188,7 +191,9 @@
 						{@const other = ($simulationStore.agents as Record<string, AgentData>)?.[otherId]}
 						<div class="kv-row">
 							<span class="kv-key">{other?.name ?? otherId}</span>
-							<span class="kv-value">count:{rel.interaction_count} score:{rel.score.toFixed(2)}</span>
+							<span class="kv-value"
+								>count:{rel.interaction_count} score:{rel.score.toFixed(2)}</span
+							>
 						</div>
 					{/each}
 				{:else}
@@ -206,7 +211,9 @@
 						<span class="kv-key">Name</span>
 						<span class="kv-value" style="display:flex;align-items:center;gap:6px;">
 							{#if faction}
-								<span style="width:12px;height:12px;border-radius:50%;background:{faction.color};display:inline-block;"></span>
+								<span
+									style="width:12px;height:12px;border-radius:50%;background:{faction.color};display:inline-block;"
+								></span>
 								{faction.name}
 							{:else}
 								{agent.faction_id}

--- a/frontend/src/lib/components/ColonyInfo.svelte
+++ b/frontend/src/lib/components/ColonyInfo.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+	import { simulationStore } from '$lib/stores/simulationStore.svelte.js';
+
+	interface ColonyStats {
+		population: number;
+		births: number;
+		deaths: number;
+		total_resources: Record<string, number>;
+	}
+
+	interface Faction {
+		id: string;
+		name: string;
+		color: string;
+		member_count: number;
+		shared_resources: Record<string, number>;
+	}
+
+	let colony = $derived(($simulationStore.colony_stats ?? null) as ColonyStats | null);
+	let factions = $derived(($simulationStore.factions ?? {}) as Record<string, Faction>);
+	let showPanel = $state(false);
+
+	function toggle() {
+		showPanel = !showPanel;
+	}
+</script>
+
+<button class="colony-toggle" onclick={toggle} aria-label="Toggle colony info">
+	{showPanel ? 'Hide Colony' : 'Colony'}
+</button>
+
+{#if showPanel && colony}
+	<div class="colony-panel">
+		<h3 class="title">Colony Info</h3>
+
+		<div class="section">
+			<div class="kv-row">
+				<span class="kv-key">Population</span>
+				<span class="kv-value">{colony.population ?? 0}</span>
+			</div>
+			<div class="kv-row">
+				<span class="kv-key">Births</span>
+				<span class="kv-value">{colony.births ?? 0}</span>
+			</div>
+			<div class="kv-row">
+				<span class="kv-key">Deaths</span>
+				<span class="kv-value">{colony.deaths ?? 0}</span>
+			</div>
+		</div>
+
+		{#if colony.total_resources && Object.keys(colony.total_resources).length > 0}
+			<div class="section">
+				<h4 class="section-title">Total Resources</h4>
+				{#each Object.entries(colony.total_resources) as [res, qty] (res)}
+					<div class="kv-row">
+						<span class="kv-key">{res}</span>
+						<span class="kv-value">{qty}</span>
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		{#if factions && Object.keys(factions).length > 0}
+			<div class="section">
+				<h4 class="section-title">Factions</h4>
+				{#each Object.values(factions) as f (f.id)}
+					<div class="faction-card">
+						<div class="faction-header">
+							<span class="faction-dot" style="background-color: {f.color};"></span>
+							<span class="faction-name">{f.name}</span>
+							<span class="faction-count">({f.member_count})</span>
+						</div>
+						{#if f.shared_resources && Object.keys(f.shared_resources).length > 0}
+							<div class="faction-resources">
+								{#each Object.entries(f.shared_resources) as [res, qty] (res)}
+									<span class="resource-tag">{res}: {qty}</span>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.colony-toggle {
+		position: fixed;
+		right: 8px;
+		bottom: 8px;
+		z-index: 20;
+		background: rgba(0, 0, 0, 0.75);
+		color: #fff;
+		border: 1px solid rgba(255, 255, 255, 0.25);
+		padding: 6px 12px;
+		border-radius: 6px;
+		font-size: 13px;
+		cursor: pointer;
+		backdrop-filter: blur(4px);
+	}
+
+	.colony-panel {
+		position: fixed;
+		right: 8px;
+		bottom: 44px;
+		width: 240px;
+		max-height: 60vh;
+		overflow-y: auto;
+		background: rgba(0, 0, 0, 0.85);
+		color: #fff;
+		padding: 14px;
+		border-radius: 8px;
+		font-family: system-ui, -apple-system, sans-serif;
+		font-size: 13px;
+		z-index: 20;
+		backdrop-filter: blur(4px);
+	}
+
+	.title {
+		margin: 0 0 10px;
+		font-size: 14px;
+		font-weight: 600;
+	}
+
+	.section {
+		border-top: 1px solid rgba(255, 255, 255, 0.1);
+		padding: 8px 0;
+	}
+
+	.section:first-of-type {
+		border-top: none;
+	}
+
+	.section-title {
+		margin: 0 0 6px;
+		font-size: 12px;
+		font-weight: 600;
+		color: #aaa;
+	}
+
+	.kv-row {
+		display: flex;
+		justify-content: space-between;
+		margin-bottom: 4px;
+		font-size: 12px;
+	}
+
+	.kv-key {
+		color: #aaa;
+	}
+
+	.kv-value {
+		font-weight: 500;
+	}
+
+	.faction-card {
+		background: rgba(255, 255, 255, 0.05);
+		border-radius: 6px;
+		padding: 6px 8px;
+		margin-bottom: 6px;
+	}
+
+	.faction-header {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.faction-dot {
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+		display: inline-block;
+	}
+
+	.faction-name {
+		font-weight: 500;
+	}
+
+	.faction-count {
+		color: #aaa;
+		font-size: 11px;
+	}
+
+	.faction-resources {
+		margin-top: 4px;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+	}
+
+	.resource-tag {
+		font-size: 11px;
+		background: rgba(255, 255, 255, 0.1);
+		padding: 2px 6px;
+		border-radius: 4px;
+	}
+</style>

--- a/frontend/src/lib/components/ColonyInfo.svelte
+++ b/frontend/src/lib/components/ColonyInfo.svelte
@@ -111,7 +111,10 @@
 		color: #fff;
 		padding: 14px;
 		border-radius: 8px;
-		font-family: system-ui, -apple-system, sans-serif;
+		font-family:
+			system-ui,
+			-apple-system,
+			sans-serif;
 		font-size: 13px;
 		z-index: 20;
 		backdrop-filter: blur(4px);

--- a/frontend/src/lib/components/HUD.svelte
+++ b/frontend/src/lib/components/HUD.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { simulationStore } from '$lib/stores/simulationStore.svelte.js';
 	import { uiStore } from '$lib/stores/uiStore.svelte.js';
+	import HudWidgets from './HudWidgets.svelte';
 </script>
 
 <div class="hud">
@@ -9,6 +10,7 @@
 	</div>
 	<div class="stat">Tick: {$simulationStore.tick}</div>
 	<div class="stat">Population: {$simulationStore.metrics.population}</div>
+	<HudWidgets />
 	<button class="btn" onclick={() => uiStore.setPaused(!$uiStore.paused)}>
 		{$uiStore.paused ? 'Resume' : 'Pause'}
 	</button>

--- a/frontend/src/lib/components/HudWidgets.svelte
+++ b/frontend/src/lib/components/HudWidgets.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { simulationStore } from '$lib/stores/simulationStore.svelte.js';
+
+	interface ColonyStats {
+		population: number;
+		births: number;
+		deaths: number;
+		total_resources: Record<string, number>;
+	}
+
+	let colony = $derived(($simulationStore.colony_stats ?? null) as ColonyStats | null);
+	let factions = $derived(($simulationStore.factions ?? {}) as Record<string, unknown>);
+	let factionCount = $derived(Object.keys(factions).length);
+</script>
+
+<div class="hud-widgets">
+	<div class="widget" title="Population">
+		<span class="widget-icon">👥</span>
+		<span class="widget-value">{colony?.population ?? 0}</span>
+	</div>
+	<div class="widget" title="Births this session">
+		<span class="widget-icon">👶</span>
+		<span class="widget-value">{colony?.births ?? 0}</span>
+	</div>
+	<div class="widget" title="Deaths this session">
+		<span class="widget-icon">💀</span>
+		<span class="widget-value">{colony?.deaths ?? 0}</span>
+	</div>
+	<div class="widget" title="Active factions">
+		<span class="widget-icon">🚩</span>
+		<span class="widget-value">{factionCount}</span>
+	</div>
+</div>
+
+<style>
+	.hud-widgets {
+		display: flex;
+		gap: 10px;
+		align-items: center;
+	}
+
+	.widget {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		background: rgba(255, 255, 255, 0.08);
+		padding: 4px 10px;
+		border-radius: 6px;
+		font-size: 13px;
+	}
+
+	.widget-icon {
+		font-size: 14px;
+	}
+
+	.widget-value {
+		font-weight: 600;
+		color: #fff;
+	}
+</style>

--- a/frontend/src/lib/stores/simulationStore.svelte.js
+++ b/frontend/src/lib/stores/simulationStore.svelte.js
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 
-/** @typedef {{ tick: number, agents: Record<string, any>, tiles: Array<{x: number, y: number, resource_type: string|null, amount: number}>, metrics: { population: number, avg_hunger: number, avg_thirst: number, avg_health: number, avg_energy: number }, events: Array<{ event_id: string, type: string, severity: string, description: string, tick: number }>, connected: boolean }} SimulationState */
+/** @typedef {{ tick: number, agents: Record<string, any>, tiles: Array<{x: number, y: number, resource_type: string|null, amount: number}>, metrics: { population: number, avg_hunger: number, avg_thirst: number, avg_health: number, avg_energy: number }, events: Array<{ event_id: string, type: string, severity: string, description: string, tick: number }>, connected: boolean, colony_stats: { population: number, births: number, deaths: number, total_resources: Record<string, number> } | null, factions: Record<string, { id: string, name: string, color: string, member_count: number, shared_resources: Record<string, number> }> }} SimulationState */
 
 const INITIAL_STATE = {
 	tick: 0,
@@ -9,7 +9,9 @@ const INITIAL_STATE = {
 	metrics: { population: 0, avg_hunger: 0, avg_thirst: 0, avg_health: 0, avg_energy: 0 },
 	/** @type {Array<any>} */
 	events: [],
-	connected: false
+	connected: false,
+	colony_stats: null,
+	factions: {}
 };
 
 function createSimulationStore() {
@@ -26,13 +28,26 @@ function createSimulationStore() {
 				const MAX_EVENTS = 100;
 				const trimmed = allEvents.length > MAX_EVENTS ? allEvents.slice(-MAX_EVENTS) : allEvents;
 
+				// Normalize factions array → Record for frontend consumption
+				let factions = data.factions ?? state.factions;
+				if (Array.isArray(factions)) {
+					/** @type {Record<string, any>} */
+					const record = {};
+					for (const f of factions) {
+						if (f.id) record[f.id] = f;
+					}
+					factions = record;
+				}
+
 				return {
 					...state,
 					tick: data.tick ?? state.tick,
 					agents: data.agents ?? state.agents,
 					tiles: data.tiles ?? state.tiles,
 					metrics: data.metrics ?? state.metrics,
-					events: trimmed
+					events: trimmed,
+					colony_stats: data.colony_stats ?? state.colony_stats,
+					factions
 				};
 			});
 		},

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import MetricChart from '$lib/components/MetricChart.svelte';
 	import AgentInspector from '$lib/components/AgentInspector.svelte';
 	import EventLog from '$lib/components/EventLog.svelte';
+	import ColonyInfo from '$lib/components/ColonyInfo.svelte';
 	import { connect, disconnect } from '$lib/components/ws.js';
 
 	onMount(() => {
@@ -19,6 +20,7 @@
 	<MetricChart />
 	<AgentInspector />
 	<EventLog />
+	<ColonyInfo />
 </div>
 
 <style>

--- a/openspec/changes/archive/agent-society/archive-report.md
+++ b/openspec/changes/archive/agent-society/archive-report.md
@@ -1,0 +1,107 @@
+# Archive Report: agent-society
+
+## Summary
+
+The "agent-society" change built a complete social simulation layer on top of the existing simulation engine. Agents evolved from isolated, asocial survival to a full society with relationships, conversations, trade, childhood dependency, factions, limited perception (knowledge), LLM action feedback, and colony-level UI. The implementation spanned 8 features across 5 phases, following the SDD workflow through proposal, spec, design, tasks, implementation, and verification phases.
+
+## Features Implemented
+
+- **F1 — LLM-Triggered Action Feedback**: `ActionResult` now carries `action_type` and `action_summary` fields. The result of each action (success/failure, stat deltas, inventory changes) is passed as `last_action_result` to the agent's next LLM prompt. Consumed after prompt build to prevent stale context. LLM timeouts discard the pending result and fall back to instinct behavior.
+
+- **F2 — Limited Knowledge / Perception**: Resource tiles gained `subtype` (e.g., `POISONOUS_BERRY`, `SAFE_BERRY`) and `hidden_properties` (e.g., `{"is_poisonous": True}`) not visible in snapshots. Agents learn hidden properties by consuming resources, stored per-agent in `knowledge` dict. Knowledge appears in LLM prompts and can be shared via conversations. Frontend shows known subtypes in AgentInspector.
+
+- **F3 — Childhood / Parental Care**: Newborn agents spawn with `is_child=True`, `parent_id`, `maturity_age` (300-700 ticks). Children cannot EAT/DRINK independently. The `FEED_CHILD` action lets caregivers reduce child hunger/thirst. Stats are inherited from parent ± random offset. Caregivers prioritize children over own needs. Orphans are adopted by nearest adult or die if none exists.
+
+- **F4 — Factions**: `Faction` dataclass and `FactionManager` with full CRUD. Three default factions (River Clan, Stone Hold, Green Ward). Agents assigned to factions on spawn. Death transfers inventory to faction's `shared_resources`. Same-faction trade preference via LLM context. Canvas renders faction-colored borders. AgentInspector shows faction info.
+
+- **F5 — Trading**: `TRADE` action with offer/request negotiation. Proposer specifies resources to give and request. Target LLM evaluates and accepts/rejects. Accepted trades execute atomically (both inventories updated). Rejected trades log without changes. Successful trades increment `interaction_count` for relationship tracking.
+
+- **F6 — Socialization / Conversations**: `ConversationManager` with proximity-based encounter detection. Messages enqueued FIFO (max 50 per agent). Max 5 conversation pairs per tick. Knowledge sharing happens automatically during encounters via `share_knowledge` messages. Conversation events logged as SimEvents with type `"socialize"`.
+
+- **F7 — Colony Info**: `ColonyStatsCollector` tracks births/deaths/population/resources. REST endpoint `GET /api/colony` returns full demographics. WebSocket snapshot includes `colony_stats` subset. `ColonyInfo.svelte` panel shows population, births, deaths, total resources, and factions. `HudWidgets.svelte` shows key metrics as minimal counters.
+
+- **F8 — Relationship-Based Reproduction**: `RelationshipData` dataclass tracks `interaction_count`, `last_interaction_tick`, and `score` per agent pair. `REPRODUCE` gated by `INTERACTION_THRESHOLD=5`. Relationships decay after 100 ticks without interaction. AgentInspector shows relationships section.
+
+## Files Created (7 new)
+
+- **`backend/app/simulation/faction.py`** — Faction dataclass + FactionManager with full CRUD, default factions, and death inventory transfer
+- **`backend/app/simulation/conversation.py`** — Message dataclass + ConversationManager with encounter detection, queue management, and knowledge sharing
+- **`backend/app/simulation/colony.py`** — ColonyStats dataclass + ColonyStatsCollector for demographics and resource aggregation
+- **`backend/app/api/colony.py`** — FastAPI REST endpoint `GET /api/colony` returning full colony statistics
+- **`frontend/src/lib/components/ColonyInfo.svelte`** — Folding panel with population, demographics, resources, and faction cards
+- **`frontend/src/lib/components/HudWidgets.svelte`** — Minimal HUD counters for population, births, deaths, and faction count
+- **`backend/tests/test_social.py`** — 58 tests covering all social features (F1 through F8)
+
+## Files Modified (14)
+
+- **`backend/app/simulation/agent.py`** — Added `last_action_result`, `relationships`, `knowledge`, `conversation_queue`, `is_child`, `parent_id`, `maturity_age`, `faction_id` fields
+- **`backend/app/simulation/actions.py`** — Added `TRADE`, `SOCIALIZE`, `FEED_CHILD` action types and handlers; `action_type`/`action_summary` on `ActionResult`; knowledge reveal in `handle_eat()`
+- **`backend/app/simulation/engine.py`** — New tick phases: social interactions, faction processing; `_update_relationship()`, `_find_reproduction_partner()` gated; conversation/faction/colony managers instantiated; colony stats collection; LLM feedback loop
+- **`backend/app/simulation/world.py`** — Added `subtype` and `hidden_properties` to Tile
+- **`backend/app/ai/prompts.py`** — New prompt sections: `LAST ACTION RESULT`, `KNOWLEDGE`, `SOCIAL CONTEXT`, `FACTION`; expanded JSON format with trade/social/feed_child
+- **`backend/app/ai/orchestrator.py`** — Prompt builder enhanced with action feedback, knowledge, faction context, social context
+- **`backend/app/models/schemas.py`** — Extended AgentState with relationships, faction_id, is_child, knowledge; WorldSnapshot with colony_stats and factions
+- **`backend/app/simulation/snapshot.py`** — Snapshot builder includes relationships, faction_id, is_child, knowledge, colony_stats, factions
+- **`backend/app/simulation/event_queue.py`** — Added event types: trade, socialize, faction_join, faction_leave, knowledge_shared, adoption
+- **`backend/app/main.py`** — Registered colony router
+- **`frontend/src/lib/stores/simulationStore.svelte.js`** — Added `colony_stats` and `factions` fields; updateFromSnapshot consumes social data
+- **`frontend/src/lib/components/AgentInspector.svelte`** — Added Relationships, Faction, Knowledge, Child Status sections
+- **`frontend/src/lib/canvas/entities.ts`** — Added `factionColor` to AgentRenderData; draws colored border for faction members
+- **`frontend/src/lib/canvas/engine.ts`** — Passes faction data to entity updates
+
+## Test Results
+
+- **107 tests passing** (49 existing + 58 new social tests)
+  - `test_ai.py`: 10 tests (existing)
+  - `test_engine.py`: 36 tests (existing)
+  - `test_health.py`: 1 test (existing)
+  - `test_websocket.py`: 2 tests (existing)
+  - `test_social.py`: 58 tests (new — covers F1 through F8)
+- **Frontend**: 0 TypeScript errors (`svelte-check` clean)
+- **Backward compatibility**: All existing tests pass without modification
+
+## Key Technical Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Social subsystems ownership | Engine-owned manager objects (ConversationManager, FactionManager, ColonyStatsCollector) | Simpler lifecycle — no extra async service; shares the same event queue and snapshot cycle; minimal coupling |
+| Knowledge store location | Dict on Agent (`knowledge: dict[str, dict]`) | Per-agent, in-memory, no persistence needed; matches existing inventory pattern |
+| Conversation message format | Structured dict (`{"type": "greeting", ...}`) | Parseable by LLM without hallucination risk; NL generation deferred |
+| Faction persistence | In-memory dict on engine (`dict[str, Faction]`) | Matches existing in-memory pattern; no DB migrations needed |
+| Colony stats delivery | Both REST (initial load) + WebSocket (live updates) | REST gives full data on page load; WS delta for live updates without polling |
+| Action feedback mechanism | `ActionResult` stored in `Agent.last_action_result` | LLM prompt builder reads it from agent; reset after read (1-tick lifespan) |
+| Orphan adoption | Automatic (nearest adult) | Reliable, no LLM dependency for critical survival path |
+| Trade rejection default | Rejection on LLM timeout | Safe default — never loses resources by accident |
+| Childhood LLM | Children skip LLM entirely | Instinct-only movement near parent; LLM call is wasted on non-autonomous agent |
+
+## Learnings
+
+1. **Tick phase ordering matters**: Proximity-based social interactions had to come AFTER FSM execution but BEFORE snapshot building. Getting the ordering wrong caused agents to act on stale social context.
+
+2. **Action feedback lifespan is critical**: Keeping `last_action_result` alive for exactly one tick and clearing it after prompt consumption prevents stale context accumulation. Multiple tests caught edge cases where timeouts would retain old state.
+
+3. **Conversation spam is real**: Even with 5 pairs/tick cap, the O(n²) proximity check for 20 agents generates 190 pairs. The `_pending_pairs` deferral mechanism was essential to prevent tick loop slowdown.
+
+4. **Knowledge sharing during encounters is elegant**: The `detect_encounters()` method automatically shares knowledge from knowledgeable agents to ignorant ones via `share_knowledge` messages. This creates emergent information diffusion without explicit LLM intervention.
+
+5. **Faction colors on canvas**: The approach of resolving faction color in `updateFromSnapshot()` via a lookup dict avoids coupling the canvas renderer to the faction manager. Clean separation of concerns.
+
+6. **Child stat inheritance**: Using `parent.stat ± random(0, 15)` with clamp to [0, 100] creates natural variation while keeping stats in valid range. The ±15 window ensures children are similar but not identical to parents.
+
+7. **Trade atomicity**: The two-phase trade (proposal → evaluation → execution) required careful state management across ticks. The proposer's resources must remain locked during evaluation, or a race condition could allow double-spending.
+
+## Next Steps
+
+1. **Add ChromaDB persistence for agent memory** — Currently agent memory is in-memory only. ChromaDB would enable long-term memory across sessions and richer LLM context.
+
+2. **Faction leadership hierarchy** — Currently factions are flat. Adding leader/follower roles, elections, or emergent leadership would increase depth.
+
+3. **Natural language conversations** — The structured message format works well, but NL generation would make conversations more engaging and varied.
+
+4. **Territory/ownership system** — Agents could claim territory, build structures, and defend resources, creating more complex faction dynamics.
+
+5. **Performance optimization** — The O(n²) proximity check could be optimized with spatial partitioning (grid cells) for larger populations.
+
+6. **War/conflict system** — Faction vs faction conflict, resource raids, and defensive behaviors would complete the societal model.
+
+7. **Colony panel enhancements** — Add charts for population trends over time, resource production/consumption rates, and faction influence metrics.

--- a/openspec/changes/archive/agent-society/design.md
+++ b/openspec/changes/archive/agent-society/design.md
@@ -1,0 +1,565 @@
+# Design: Agent Society
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                      SimulationEngine                               │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌───────────────────┐  │
+│  │ Needs    │  │ FSM      │  │ LLM      │  │ SocialSubsystems  │  │
+│  │ Decay    │→ │ Runner   │→ │ Polling  │  │                   │  │
+│  └──────────┘  └──────────┘  └──────────┘  │ ┌───────────────┐ │  │
+│                                              │ │ Conversation  │ │  │
+│  ┌──────────────────────────────────────┐   │ │ Manager       │ │  │
+│  │          Tick Phases                 │   │ └───────────────┘ │  │
+│  │ 1. needs 2. fsm 3. events 4. llm    │   │ ┌───────────────┐ │  │
+│  │ 5. regen 6. proximity 7. social     │   │ │ Trade Handler │ │  │
+│  │ 8. faction 9. snapshot 10. db       │   │ └───────────────┘ │  │
+│  └──────────────────────────────────────┘   │ ┌───────────────┐ │  │
+│                                              │ │ Faction Mgmt  │ │  │
+│  ┌──────────┐  ┌──────────┐                 │ └───────────────┘ │  │
+│  │ World    │  │ Agent    │                 │ ┌───────────────┐ │  │
+│  │ (subtypes)│  │ (social) │                 │ │ Knowledge     │ │  │
+│  └──────────┘  └──────────┘                 │ │ Store        │ │  │
+│                                              │ └───────────────┘ │  │
+│  ┌──────────────────┐  ┌─────────────────┐  └───────────────────┘  │
+│  │ EventQueue       │  │ SnapshotBuilder │                        │
+│  │ (new types added)│  │ (colony_stats)  │                        │
+│  └──────────────────┘  └─────────────────┘                        │
+└─────────────────────────────────────────────────────────────────────┘
+                            │ WebSocket
+                            ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                     Frontend (Svelte 5)                              │
+│  ┌──────────────┐  ┌──────────────┐  ┌───────────────────────────┐  │
+│  │ Canvas       │  │ Agent        │  │ ColonyInfo Panel          │  │
+│  │ (faction     │  │ Inspector    │  │ (demographics, resources, │  │
+│  │  borders)    │  │ (relationships)│  │ factions, HUD widgets)   │  │
+│  └──────────────┘  └──────────────┘  └───────────────────────────┘  │
+│                      ▲ store.subscribe                               │
+│              ┌───────┴────────┐                                      │
+│              │ simulationStore │                                      │
+│              │ (social data)   │                                      │
+│              └────────────────┘                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## Architecture Decisions
+
+| Decision | Options | Choice | Rationale |
+|----------|---------|--------|-----------|
+| Social subsystems as engine-owned managers vs standalone service | Standalone service vs Engine-owned managers | Engine-owned manager objects | Simpler lifecycle — no extra async service; shares the same event queue and snapshot cycle; minimal coupling |
+| Knowledge store in Agent dataclass vs separate service | Dict on Agent vs external db | Dict on Agent (`knowledge: dict[str, dict]`) | Per-agent, in-memory, no persistence needed across runs; matches existing `inventory` pattern |
+| Conversation message format | NL vs structured dict | Structured dict (`{"type": "...", ...}`) | Per spec — NL generation deferred; structured is parseable by LLM without hallucination risk |
+| Faction persistence | File vs DB vs in-memory | In-memory dict on engine (`dict[str, Faction]`) | Matches existing in-memory pattern of engine; no DB migrations needed |
+| Colony stats — REST vs WS-only | Both vs WS-only | Both (REST for initial load, WS for live updates) | REST gives full data on page load; WS delta for live updates without polling |
+| Action feedback mechanism | `ActionResult` stored on Agent vs passed in prompt | `ActionResult` stored in `Agent.last_action_result: Optional[ActionResult]` | LLM prompt builder reads it from agent; reset after read to avoid stale context |
+
+## Module-by-Module Design
+
+### 1. Data Layer
+
+#### New entities
+
+```
+backend/app/simulation/
+├── faction.py          # NEW — Faction dataclass + CRUD
+├── conversation.py     # NEW — Message dataclass + ConversationManager
+├── knowledge.py        # NEW — KnowledgeStore dataclass (per-agent)
+└── colony.py           # NEW — ColonyStats collector
+```
+
+**Faction** (`faction.py`):
+```python
+@dataclass
+class Faction:
+    id: str
+    name: str
+    color: str           # hex, e.g. "#FF0000"
+    member_ids: list[str]
+    shared_resources: dict[str, int]  # resource_name → count
+```
+
+**Message** (`conversation.py`):
+```python
+@dataclass
+class Message:
+    sender_id: str
+    content: dict        # structured: {"type": "greeting"|"share_knowledge"|"trade_proposal"|...}
+    tick: int
+
+class ConversationManager:
+    max_pairs_per_tick: int = 5
+    max_queue_size: int = 50
+    _pending_pairs: list[tuple[str, str]]  # deferred pairs
+    def detect_encounters(agents, radius, tick) -> None
+    def process_next_pair(agent_a, agent_b, world) -> tuple[Message, Message] | None
+```
+
+**Knowledge** (`knowledge.py`):
+```python
+# Each agent gets: agent.knowledge: dict[str, dict[str, Any]]
+# Key: subtype name (e.g. "POISONOUS_BERRY")
+# Value: {property: value} (e.g. {"is_poisonous": True})
+```
+
+**ColonyStats** (`colony.py`):
+```python
+@dataclass
+class ColonyStats:
+    population: int
+    births: int           # session total
+    deaths: int           # session total
+    role_distribution: dict[str, int]
+    sex_distribution: dict[str, int]
+    age_groups: dict[str, int]  # "child": N, "adult": N, "elder": N
+    total_resources: dict[str, int]
+    factions: list[FactionSummary]
+```
+
+#### Changes to existing models
+
+**Agent** — new fields:
+- `relationships: dict[str, RelationshipData]` — F8
+- `faction_id: str | None = None` — F4
+- `is_child: bool = False` / `parent_id: str | None = None` / `maturity_age: int = 500` — F3
+- `knowledge: dict[str, dict[str, Any]] = field(default_factory=dict)` — F2
+- `conversation_queue: list[Message] = field(default_factory=list)` — F6
+- `last_action_result: Optional[ActionResult] = None` — F1
+- `interaction_count: int = 0` (legacy counter), replaced by `relationships` dict lookup
+
+```python
+@dataclass
+class RelationshipData:
+    interaction_count: int
+    last_interaction_tick: int
+    score: float  # -1.0 to 1.0
+```
+
+**Tile** (`world.py`) — new field:
+- `subtype: str | None = None` — e.g. "POISONOUS_BERRY", "SAFE_BERRY", "OAK_TREE"
+- `hidden_properties: dict[str, Any] = field(default_factory=dict)` — e.g. `{"is_poisonous": True}`
+
+**ActionResult** (`actions.py`) — add `action_type: ActionType` and `action_summary: str`:
+```python
+@dataclass
+class ActionResult:
+    success: bool = True
+    events: list[dict] = field(default_factory=list)
+    interrupted: bool = False
+    state_changes: dict[str, Any] = field(default_factory=dict)
+    action_type: ActionType | None = None     # NEW
+    action_summary: str = ""                  # NEW — e.g. "hunger:-30, wood:+5"
+```
+
+**AgentState** (Pydantic schema, `schemas.py`) — new fields:
+- `relationships: dict[str, dict] = {}` — F8
+- `faction_id: str | None = None` — F4
+- `is_child: bool = False` — F3
+- `knowledge: list[str] = []` — F2 (subset: list of known subtype names)
+- `interaction_count: int = 0` (aggregate for quick display)
+
+**WorldSnapshot** (Pydantic) — new field:
+- `colony_stats: dict | None = None` — F7 (subset: population, births, deaths, total_resources)
+
+**SimEvent** (`event_queue.py`) — new event types:
+- `"trade"`, `"socialize"`, `"faction_join"`, `"faction_leave"`, `"knowledge_shared"`, `"adoption"`
+
+#### ORM changes (`db/models.py`)
+
+- `TickMetrics`: add `total_factions`, `total_children` columns (non-breaking, nullable default 0).
+- No new tables needed — faction data is transient (in-memory).
+
+### 2. Simulation Engine Changes
+
+#### FSM state changes
+
+| Current State | New Transitions | Feature |
+|--------------|-----------------|---------|
+| `"idle"` | → `"evaluate"` (unchanged) | — |
+| `"evaluate"` | **NEW**: check conversation_queue → process social message / trade proposal | F5, F6 |
+| `"evaluate"` | **NEW**: if `is_child`, skip EAT/DRINK actions | F3 |
+| `"evaluate"` | **MODIFIED**: REPRODUCE gated by `interaction_count >= threshold` | F8 |
+| `"evaluate"` | **MODIFIED**: LLM prompt includes `last_action_result` context | F1 |
+| `"llm_trigger"` | **MODIFIED**: `build_prompt()` includes knowledge + relationships + action result | F1, F2, F8 |
+| New: `"social_interaction"` | Agent processes conversation queue during this dedicated state | F6 |
+
+#### New method: `_process_social_interactions(tick)`
+
+Called in a new tick phase between proximity checks and snapshot:
+
+```python
+async def _process_social_interactions(self, tick: int) -> None:
+    # 1. Detect encounters via proximity (reuse existing check_proximity_encounters)
+    # 2. For each pair within radius, enqueue Messages in both agents' queues
+    # 3. Enforce max 5 pairs/tick; defer remainder
+    # 4. For agents in IDLE with non-empty queue, transition to llm_trigger
+    #    with the queue content as trigger context
+    # 5. Process trade proposals (evaluate target agent's response)
+```
+
+#### New tick phases in `_tick()`:
+
+```
+1. _process_needs(tick)
+2. For each agent: _run_agent_fsm(agent, tick)
+3. _process_social_interactions(tick)       # NEW — conversations & trade
+4. _process_faction_agent_death(tick)        # NEW — transfer inventory on death
+5. self.event_queue.drain()
+6. _poll_llm_responses(tick)
+7. self.world.regenerate_resources()
+8. check_proximity_encounters()             # Existing (encounter events)
+9. check_resource_discoveries()             # Existing (now includes subtype detection)
+10. Build + broadcast snapshot (with colony_stats)
+```
+
+#### Action changes
+
+**New ActionType values:**
+- `TRADE = "trade"` — with handler `handle_trade()` in `actions.py`
+- `SOCIALIZE = "socialize"` — trigger for conversation processing
+- `FEED_CHILD = "feed_child"` — caregiver feeds child agent
+
+**Modified handlers:**
+
+| Handler | Change | Feature |
+|---------|--------|---------|
+| `handle_eat()` | Reveal hidden properties of consumed resource subtype → update agent.knowledge | F2 |
+| `handle_eat()` | If agent is_child → block action | F3 |
+| `handle_reproduce()` | Check `interaction_count >= INTERACTION_THRESHOLD` → else fail | F8 |
+| All handlers | Populate `ActionResult.action_type` and `action_summary` | F1 |
+
+**New handlers:**
+
+```
+handle_trade(agent, world, target, step) -> ActionResult
+  - Validate proposer has offer resources
+  - Enqueue trade proposal in target's conversation_queue
+  - Target LLM evaluates in next tick
+  - On accept: atomic swap; on reject: no-op
+  - Increment interaction_count for both
+
+handle_feed_child(agent, world, target, step) -> ActionResult
+  - target = child_id
+  - Transfer 1 berry from caregiver to satisfy child hunger -30
+  - Child must be within interaction radius
+```
+
+#### Faction management (new `faction.py`):
+
+```python
+class FactionManager:
+    def __init__(self): self.factions: dict[str, Faction] = {}
+    def create(name, color) -> Faction
+    def delete(faction_id) -> bool
+    def join(agent_id, faction_id) -> bool
+    def leave(agent_id, faction_id) -> bool
+    def list_all() -> list[FactionSummary]
+    def transfer_inventory_on_death(agent) -> None
+    def get_faction(faction_id) -> Faction | None
+    def get_all() -> dict[str, Faction]
+```
+
+### 3. AI / LLM Integration
+
+#### Prompt changes (`prompts.py`)
+
+**`build_agent_prompt()`** gets new parameters and sections:
+
+```
+LAST ACTION RESULT:
+- Action: {action_type}
+- Success: {true/false}
+- Effects: {action_summary}   # e.g. "hunger:-30, wood:+3, food:-1"
+
+KNOWLEDGE:
+- You know: POISONOUS_BERRY is poisonous
+- You know: OAK_TREE provides strong wood
+
+RELATIONSHIPS:
+- Mila: interaction_count=7, score=0.8 (faction ally)
+- Kael: interaction_count=2, score=0.3
+
+FACTION:
+- You are a member of the "River Clan" (color: #00FF00)
+
+CHILD STATUS:
+- You are caring for child {name} (hunger={h}, thirst={t})
+```
+
+New constants:
+```python
+INTERACTION_THRESHOLD = 5   # for F8
+DECAY_INTERVAL = 100        # ticks before relationship decays
+```
+
+**JSON format instruction** updated to include new action types:
+```json
+{
+  "steps": [{
+    "action": "move" | "chop" | "drink" | "eat" | "gather" | "rest" | "reproduce" | "trade" | "socialize" | "feed_child",
+    "target": [x, y] or null or agent_id,
+    ...
+  }]
+}
+```
+
+For `TRADE`:
+```json
+{
+  "action": "trade",
+  "target": "agent_002",
+  "offer": {"wood": 3},
+  "request": {"berry": 5},
+  "duration_secs": 5,
+  "reason": "Need food, have spare wood"
+}
+```
+
+#### Orchestrator changes (`orchestrator.py`)
+
+`build_prompt()` in `RealLLMOrchestrator` — enhanced:
+- Read `agent.last_action_result` → include in prompt
+- Read `agent.knowledge` → include as formatted string
+- Read `agent.relationships` → include key relationships
+- Read `agent.faction_id` → include faction context
+- Read `agent.is_child` / `agent.parent_id` → skip LLM for infants (instinct-only)
+
+After prompt consumed, reset `agent.last_action_result = None` (prevent stale context accumulation).
+
+**Concurrency management:**
+- Existing `_llm_semaphore = Semaphore(1)` already serializes Ollama calls — no change needed.
+- Social interactions (trade decisions) share the same semaphore — OK since they're per-agent.
+- Timeout fallback: trade rejection is default on timeout (safe default).
+
+### 4. Frontend
+
+#### New components
+
+| Component | File | Purpose |
+|-----------|------|---------|
+| `ColonyInfo.svelte` | `frontend/src/lib/components/ColonyInfo.svelte` | Demographics panel: pop, births, deaths, role/age distribution, resources, factions |
+| `HudWidgets.svelte` | `frontend/src/lib/components/HudWidgets.svelte` | Minimal HUD: population, births, deaths counters |
+
+#### Modified components
+
+**`AgentInspector.svelte`** — add sections:
+- "Relationships" — list of known agents with interaction_count, score, last_interaction_tick
+- "Faction" — faction name + color swatch if member
+- "Knowledge" — known resource subtypes
+- "Child Status" — if `is_child`, show parent_id and maturity progress
+
+#### Canvas changes (`entities.ts`)
+
+- **AgentRenderData** — add `factionColor: string | null` field
+- **draw()** — if `a.factionColor` set, render colored border/ring around agent circle:
+  ```typescript
+  if (a.factionColor) {
+    ctx.beginPath();
+    ctx.arc(px, py, RADIUS + 3, 0, Math.PI * 2);
+    ctx.strokeStyle = a.factionColor;
+    ctx.lineWidth = 3;
+    ctx.stroke();
+  }
+  ```
+- **updateFromSnapshot()** — read `faction_id` from state, resolve color via lookup
+
+#### Store changes (`simulationStore.svelte.js`)
+
+- Add new fields to `SimulationState` type:
+  - `colony_stats: object`
+  - `factions: Record<string, {id, name, color, member_count, shared_resources}>`
+- `updateFromSnapshot()` — consume `colony_stats` and `factions` from snapshot payload
+
+## Integration Points
+
+```
+Feature         Produces                    Consumes                    Via
+──────          ────────                    ────────                    ───
+F1 (feedback)   ActionResult on Agent        LLM prompt builder         Agent.last_action_result
+F2 (knowledge)  agent.knowledge dict         LLM prompt builder         build_prompt() reads knowledge
+                hidden properties on Tile    Agent consume action       handle_eat() reveals
+                knowledge shared via Msg     ConversationManager        Message.content
+F3 (childhood)  agent.is_child field         FSM evaluate() blocks      agent.current_action check
+                parent_id                    FEED_CHILD action          handle_feed_child()
+F4 (factions)   Faction dataclass            Snapshot builder           engine.faction_manager
+                agent.faction_id             Canvas renderer            agent.faction_id → color
+                shared_resources             Death handler               faction_manager.transfer()
+F5 (trade)      Trade proposal Message       Target LLM eval            conversation_queue
+                action result                Tick phase 3               _process_social_interactions()
+F6 (social)     Message enqueue              Agent conversation_queue   conversation_manager
+                knowledge share              Target knowledge store     Message.content["share_knowledge"]
+F7 (colony UI)  ColonyStats                  Snapshot.colony_stats       colony.py collector
+                GET /api/colony               ColonyInfo.svelte          REST endpoint
+F8 (relations)  relationships dict           REPRODUCE gating            _find_reproduction_partner()
+                interaction_count inc       Relationship decay           _process_needs() each tick
+```
+
+## Data Flow Diagrams
+
+### F1 — LLM Action Feedback (per tick per agent)
+
+```
+handle_action() → ActionResult(action_type, success, action_summary)
+       │
+       ▼
+agent.last_action_result = result
+       │
+       ▼  (next FSM cycle triggered)
+build_prompt() reads agent.last_action_result
+       │
+       ▼  (included in prompt)
+LLM receives: "LAST ACTION RESULT: CHOP success, effects: wood:+3, energy:-10"
+       │
+       ▼
+agent.last_action_result = None  (consumed)
+```
+
+### F2 — Knowledge Discovery & Sharing
+
+```
+Agent steps on/consumes resource
+       │
+       ▼
+handle_eat() checks tile.subtype → tile.hidden_properties
+       │
+       ▼
+agent.knowledge["POISONOUS_BERRY"] = {"is_poisonous": True}
+       │
+       ▼
+build_prompt(): "You know POISONOUS_BERRY is poisonous"
+       │
+       ▼
+[Optional] Agent shares via SOCIALIZE → Message.content = {"type": "share_knowledge", "subtype": "POISONOUS_BERRY", "properties": {"is_poisonous": True}}
+       │
+       ▼
+Receiver agent.knowledge updated
+```
+
+### F5 — Trade Flow
+
+```
+Agent A (proposer) LLM decides to trade → sets action=TRADE, target=agent_002, offer={wood:3}, request={berry:5}
+       │
+       ▼
+FSM executing: handle_trade() called
+       │
+       ▼
+Validates A has 3 wood → enqueues Message in B's conversation_queue: {"type": "trade_proposal", "from": "A", "offer": {...}, "request": {...}}
+       │
+       ▼
+Next tick: B's FSM processes queue → LLM prompt includes trade proposal context
+       │
+       ├── Accept → action=TRADE executed → atomic swap → interaction_count++
+       │
+       └── Reject/timeout → no-op → log SimEvent(type="trade", success=false)
+```
+
+### F8 — Relationship-based Reproduction
+
+```
+Trade/Conversation/Any interaction between A and B
+       │
+       ▼
+A.relationships[B.id].interaction_count++
+A.relationships[B.id].score += delta  (trade=+0.2, socialize=+0.1)
+B.relationships[A.id].interaction_count++
+B.relationships[A.id].score += delta
+       │
+       ▼
+Each tick in _process_needs():
+  - Check decay: if tick - last_interaction_tick > DECAY_INTERVAL → decrement count
+       │
+       ▼
+_find_reproduction_partner(agent):
+  - Only considers agents with relationships[other].interaction_count >= INTERACTION_THRESHOLD (5)
+  - Also checks compatibility: opposite sex, energy > 20, within radius
+       │
+       ▼
+If no partner found → skip reproduction → LLM for higher-level planning
+```
+
+## Testing Strategy
+
+| Layer | Feature | Tests | Approach |
+|-------|---------|-------|----------|
+| **Unit** | F1 | `test_action_result_captured` | Create ActionResult, assign to agent, verify `build_prompt()` includes it |
+| **Unit** | F1 | `test_action_result_null_on_first_tick` | New agent → `last_action_result` is None |
+| **Unit** | F1 | `test_action_result_cleared_after_read` | After prompt built, verify field is None |
+| **Unit** | F2 | `test_tile_with_subtype` | Create Tile with subtype+hidden, verify world snapshot does NOT expose hidden |
+| **Unit** | F2 | `test_eat_reveals_hidden_properties` | Agent eats POISONOUS_BERRY → `knowledge["POISONOUS_BERRY"]` populated |
+| **Unit** | F2 | `test_knowledge_is_per_agent` | Two agents, one eats → knowledge differs |
+| **Unit** | F2 | `test_knowledge_in_prompt` | Agent with knowledge → string appears in built prompt |
+| **Unit** | F2 | `test_knowledge_share_via_message` | Direct update of other agent's knowledge via Message |
+| **Unit** | F3 | `test_child_blocks_eat` | Agent with is_child=True → handle_eat() returns failure |
+| **Unit** | F3 | `test_feed_child_action` | Caregiver has berries, child nearby → hunger decreases, inventory decreases |
+| **Unit** | F3 | `test_child_stat_inheritance` | Parent stats ± random(0,15), children within expected range |
+| **Unit** | F3 | `test_child_maturity` | Tick reaches maturity_age → is_child=False |
+| **Unit** | F3 | `test_orphan_adoption` | Caregiver dies, closest adult within radius adopts |
+| **Unit** | F4 | `test_faction_crud` | Create, delete, join, leave, list |
+| **Unit** | F4 | `test_faction_death_transfer` | Agent dies → inventory moves to faction.shared_resources |
+| **Unit** | F5 | `test_trade_atomic_swap` | Both have sufficient → both inventories update correctly |
+| **Unit** | F5 | `test_trade_insufficient_funds` | Proposer lacks resources → fail, no change |
+| **Unit** | F5 | `test_trade_interaction_count` | Successful trade increments both agents' count |
+| **Unit** | F6 | `test_conversation_enqueue` | Two agents within radius → messages in both queues |
+| **Unit** | F6 | `test_max_queue_size` | 60 messages pushed → only last 50 kept |
+| **Unit** | F6 | `test_max_pairs_per_tick` | 10 pairs pending → only 5 processed, 5 deferred |
+| **Unit** | F8 | `test_relationship_data` | Interaction between agents → relationship entry created with correct fields |
+| **Unit** | F8 | `test_reproduce_gated_by_interactions` | interaction_count < threshold → no partner found |
+| **Unit** | F8 | `test_relationship_decay` | After decay interval, interaction_count decrements |
+| **Integration** | F3+F8 | `test_child_spawn_adjacent_to_parent` | After F8 reproduction, child adjacent to parent tile |
+| **Integration** | F5+F6+F8 | `test_trade_increments_interaction_count` | Full trade flow → interaction_count updated for both |
+| **Integration** | F6+F2 | `test_knowledge_shared_via_conversation` | Full conversation flow → knowledge propagates |
+| **Integration** | F7 | `test_colony_endpoint` | HTTP GET /api/colony → correct JSON structure |
+| **Integration** | F7 | `test_colony_stats_in_snapshot` | WebSocket snapshot includes colony_stats |
+| **Integration** | Engine | `test_social_tick_performance` | 20 agents, 3 factions, conversations, trades → <150ms/tick |
+| **Regression** | All | `test_existing_engine_tests_pass` | All current tests run without modification |
+
+**Mock strategy:**
+- `MockLLMOrchestrator`: update `build_prompt()` to verify new context sections are present. Use `success_rate=1.0` for deterministic tests.
+- Trade decisions: mock LLM to return accept or reject plan deterministically.
+- Conversation: mock LLM response to include reply/share_knowledge actions.
+- Faction: use standalone `FactionManager` tests without engine.
+
+## Performance & Limits
+
+| Limit | Value | Location | Rationale |
+|-------|-------|----------|-----------|
+| Conversation queue size | 50 messages/agent | `conversation.py` | Prevents memory bloat; 50 is enough for recent context |
+| Conversation pairs/tick | 5 | `ConversationManager` | Prevents tick loop slowdown; deferred to next tick |
+| LLM concurrency | Semaphore(1) | `orchestrator.py` (existing) | Avoids overloading Ollama; trade decisions share this |
+| LLM timeout | 30s (configurable) | `settings.llm_timeout` | Existing; trade rejection on timeout is safe default |
+| Action feedback stale guard | 1 tick lifespan | `agent.last_action_result` | Reset to None after prompt build; never accumulates |
+| Relationship decay interval | 100 ticks | `engine.py` constant | Agents need ongoing interaction to maintain bonds |
+| Reproduction interaction threshold | 5 | `engine.py` constant | Minimum meaningful interactions before reproduction |
+| Faction soft cap | None (emergent) | `faction_manager` | Let dynamics emerge naturally; no hard cap |
+| Population cap | 20 (existing) | `engine.py` MAX_POPULATION | No change; existing limit still applies |
+| Max events in snapshot | 100 (existing) | `simulationStore.svelte.js` | No change; frontend limit |
+| Colony stats snapshot size | ~1KB | `WorldSnapshot.colony_stats` | Small subset of full snapshot; negligible overhead |
+
+**Performance budget for tick loop with full social features (20 agents, 3 factions):**
+
+| Phase | Est. time | Notes |
+|-------|-----------|-------|
+| Needs decay | <1ms | O(n) linear |
+| FSM run (20 agents) | ~5ms | Includes instinct checks |
+| Social interactions | ~3ms | Max 5 pairs; message enqueue is O(k) |
+| Faction processing | <1ms | Death transfer check |
+| LLM poll | <1ms | Completed future check |
+| World regen | ~2ms | O(width*height) |
+| Proximity | ~1ms | O(n²/2) for 20 = 190 pairs |
+| Snapshot build | ~5ms | All agents + dirty tiles |
+| **Total** | **<20ms** | Well under 150ms budget |
+
+## Open Questions
+
+- [ ] **F3 adoption**: Should adoption be automatic (nearest adult) or require LLM evaluation on the adopter? The spec permits either. Design defaults to automatic for reliability, but LLM opt-in could add emergent storytelling. Decision: automatic + SimEvent log ("X adopted Y").
+- [ ] **F5 trade rejection reason**: Should the LLM provide a rejection reason (for UX) or just silent reject? Tradeoff: more data vs slower ticks. Decision: include rejection reason in the SimEvent log (mutable in implementation).
+- [ ] **F6 conversation depth**: Should conversations be multi-turn within a single tick? Spec implies single message per encounter per tick. Decision: 1 message per agent per encounter per tick (matches spec).
+- [ ] **F7 colony endpoint frequency**: Should there be a rate limit on GET /api/colony? Decision: not needed — lightweight read from engine state, no DB query.
+
+## Migration / Rollout
+
+- **No data migration required.** All new fields have safe defaults (`None`, `{}`, `False`) — existing agents are backward compatible.
+- **Phased rollout per proposal**: Phase 1 (F1+F8) → Phase 2 (F6) → Phase 3 (F2+F5) → Phase 4 (F3+F4) → Phase 5 (F7). Each phase independently merges to main.
+- **Rollback plan per proposal**: revert `agent.py`, `actions.py`, `engine.py`, `world.py`, `simulationStore.svelte.js`, delete new modules (`knowledge.py`, `faction.py`, `conversation.py`, `colony.py`, `ColonyInfo.svelte`, `HudWidgets.svelte`).

--- a/openspec/changes/archive/agent-society/proposal.md
+++ b/openspec/changes/archive/agent-society/proposal.md
@@ -1,0 +1,94 @@
+# Proposal: Agent Society
+
+## Intent
+
+Agents survive independently, asocially — no bonds, no trade, no childhood, no factions, no knowledge sharing. This change builds a full social simulation layer: relationships, conversations, trade, childhood dependency, factions, limited perception, LLM action feedback, and colony-level UI.
+
+## Scope
+
+### In Scope (8 features)
+- **F1 — LLM action feedback**: LLM receives action results as context for next decision
+- **F2 — Limited perception**: Resource subtypes with hidden properties (poisonous vs safe berries), learned by experience or conversation
+- **F3 — Childhood**: Infants depend on caregivers for food/water; stats influenced by parents
+- **F4 — Factions**: Social groups with shared identity and resource pool
+- **F5 — Trade**: Resource exchange between nearby agents (TRADE action)
+- **F6 — Socialization**: Messages, information sharing, coordination (SOCIALIZE action)
+- **F7 — Colony Info panel**: Backend endpoint + frontend panel with demographics and total resources
+- **F8 — Relationship-based reproduction**: Agents need N interactions before REPRODUCE is allowed
+
+### Out of Scope
+- Territory/ownership, faction leadership hierarchy, war/combat
+- ChromaDB persistence for agent memory (deferred)
+- Natural language generation for conversations (structured messages only)
+
+## Capabilities
+
+### New Capabilities
+- `agent-society`: Full social simulation — relationships, factions, childhood dependency, trade, limited perception, LLM action feedback, and conversation system.
+
+### Modified Capabilities
+- `simulation-engine`: Extended Agent model (relationships, faction, childhood state, knowledge), new action types (TRADE, SOCIALIZE), resource subtypes with hidden properties, new FSM states for infant and social interactions.
+
+## Approach
+
+Five-phase incremental build, each independently testable:
+
+### Phase 1: Foundation (F1 + F8)
+Relationship tracking on Agent (`interaction_count`, `relationship_scores: dict[str, float]`). LLM `decide_next_action()` receives result of completed action as context. REPRODUCE gated by `interaction_count >= threshold`.
+
+### Phase 2: Social Core (F6)
+SOCIALIZE action type. `MessageQueue` per agent (FIFO, max N). Proximity-based conversation trigger in tick loop. In-memory knowledge store (dict of `{resource_type: {property: value}}`).
+
+### Phase 3: Society (F2 + F5)
+Resource subtypes (`POISONOUS_BERRY`, `SAFE_BERRY`) with hidden `is_poisonous` property. Knowledge propagation via SOCIALIZE. TRADE action: offer/accept exchange between adjacent agents.
+
+### Phase 4: Lifecycle & Groups (F3 + F4)
+Infant FSM state — cannot eat/drink, decays hunger/thirst faster, needs caregiver within radius. Caregiver assigned at birth (parent or nearest adult). Faction model (`id`, `name`, `member_ids`, `shared_inventory: dict`), join/leave CRUD.
+
+### Phase 5: Colony UI (F7)
+Backend `GET /api/colony` endpoint returning demographics (population, age distribution, factions) and total resources. `ColonyInfo.svelte` frontend panel. HUD widgets showing key metrics.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `backend/app/simulation/agent.py` | Modified | relationships, faction_id, infant_state, knowledge fields |
+| `backend/app/simulation/actions.py` | Modified | TRADE, SOCIALIZE added; REPRODUCE gated |
+| `backend/app/simulation/engine.py` | Modified | New tick phases, proximity triggers for conversation/trade |
+| `backend/app/simulation/world.py` | Modified | Resource subtypes with hidden properties |
+| `backend/app/simulation/knowledge.py` | New | Perception/learning store per agent |
+| `backend/app/simulation/faction.py` | New | Faction model + CRUD |
+| `backend/app/simulation/conversation.py` | New | Message queue + social interaction logic |
+| `backend/app/api/colony.py` | New | Colony stats endpoint |
+| `frontend/src/lib/components/ColonyInfo.svelte` | New | Demographics panel |
+| `frontend/src/lib/stores/simulationStore.svelte.js` | Modified | New social/colony data in snapshot |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| LLM latency with chained action feedback | Med | Async non-blocking; timeout → fallback instinct behavior |
+| Conversation spam slows tick loop | Low | Cap conversations/tick; FIFO max 50 per agent |
+| Infants die before caregiver arrives | Med | Always spawn adjacent to parent; fail-safe autofeed timer |
+| Faction imbalance (one dominant) | Low | Soft membership caps; emergent dynamics, not enforced |
+
+## Rollback Plan
+
+Revert `agent.py`, `actions.py`, `engine.py`, `world.py`, `simulationStore.svelte.js` to last stable commit. Delete new modules: `knowledge.py`, `faction.py`, `conversation.py`, `colony.py`, `ColonyInfo.svelte`. No DB migrations.
+
+## Dependencies
+
+- All phases depend on existing `simulation-engine` (tick loop, actions, FSM, world grid)
+- Phase 3 (knowledge) depends on Phase 2 (conversations)
+- Phase 4 (childhood) depends on Phase 1 (relationship-based reproduction)
+
+## Success Criteria
+
+- [ ] Agents perform 8+ action types (TRADE and SOCIALIZE added)
+- [ ] Relationship score gates reproduction (threshold interactions verified)
+- [ ] LLM receives prior action result as context in next decision
+- [ ] Agents discover hidden resource properties via consumption and conversation
+- [ ] Infant agents survive only when caregiver is within range
+- [ ] Factions form with shared resource pools
+- [ ] Colony panel shows demographics and total resource counts
+- [ ] All new and existing engine tests pass

--- a/openspec/changes/archive/agent-society/specs/agent-society/spec.md
+++ b/openspec/changes/archive/agent-society/specs/agent-society/spec.md
@@ -1,0 +1,177 @@
+# Spec: agent-society
+
+## Capabilities
+
+### capability: agent-society
+**Depends on**: simulation-engine
+
+Extends the core simulation with a full social simulation layer: relationships, conversations, trade, childhood dependency, factions, limited perception (knowledge), LLM action-feedback, and colony-level UI.
+
+#### Requirements
+
+**F1 — LLM-Triggered Action Feedback**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F1-R1 | The system MUST capture the `ActionResult` from each completed action (success/failure, stat deltas, inventory deltas, events produced) and pass it as structured context to the LLM on the agent's next `decide_next_action()` call. | MUST |
+| F1-R2 | The system MUST include the `ActionResult` context as a dedicated field in the LLM prompt (e.g., `last_action_result`) separate from the agent's current stats and world state. | MUST |
+| F1-R3 | If the agent has no prior action (first tick after spawn), the `last_action_result` field MUST be `null`/`None` instead of producing an error. | MUST |
+| F1-R4 | If the LLM call times out or fails, the agent MUST fall back to instinct behavior (find nearest food/water) and the pending `ActionResult` context MUST be discarded (not accumulated across ticks). | MUST |
+| F1-R5 | The `ActionResult` context MUST include the `ActionType` that was executed, the `success` boolean, and a summary of stat changes (e.g., `hunger:-30`, `wood:+5`). | MUST |
+
+**F2 — Limited Perception / Knowledge**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F2-R1 | Resources on the world grid MUST have a `subtype` field (e.g., `POISONOUS_BERRY`, `SAFE_BERRY`, `OAK_TREE`, `PINE_TREE`) in addition to the base `resource_type` (e.g., `BERRY`, `WOOD`). | MUST |
+| F2-R2 | Each resource subtype MUST define a set of `hidden_properties: dict[str, Any]` that are NOT visible to agents through vision/perception alone (e.g., `{"is_poisonous": true}` for `POISONOUS_BERRY`). | MUST |
+| F2-R3 | Agents MUST NOT receive `hidden_properties` in their world state snapshot — only the base `resource_type` and `subtype` name are visible. | MUST |
+| F2-R4 | When an agent consumes a resource (EAT action), the hidden properties of that resource's subtype MUST be revealed to the agent and stored in the agent's individual `knowledge` store. | MUST |
+| F2-R5 | Each agent MUST have an independent `knowledge: dict[str, dict[str, Any]]` store mapping `subtype_name -> {property: value}`. Agent A learning that `POISONOUS_BERRY` is poisonous does NOT mean Agent B knows it. | MUST |
+| F2-R6 | The agent's LLM prompt MUST include the agent's known knowledge as context when making decisions about resources (e.g., "You know that POISONOUS_BERRY is poisonous"). | MUST |
+| F2-R7 | Knowledge discovered by one agent MUST be shareable with another agent via the conversation system (F6). Shared knowledge is added to the receiving agent's `knowledge` store. | MUST |
+
+**F3 — Childhood and Parental Care**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F3-R1 | Newborn agents MUST be created with `is_child: bool = True` and `parent_id: str` pointing to their parent agent's ID. | MUST |
+| F3-R2 | Child agents MUST NOT be able to execute `EAT` or `DRINK` actions independently. If a child's FSM attempts to eat/drink, it MUST be blocked. | MUST |
+| F3-R3 | A new `FEED_CHILD` action type MUST be added. The caregiver executes `FEED_CHILD(child_id)` which transfers resources from the caregiver's inventory to satisfy the child's hunger/thirst. | MUST |
+| F3-R4 | A child agent MUST spawn adjacent to its parent (Manhattan distance ≤ 2). | MUST |
+| F3-R5 | The parent/caregiver's FSM MUST prioritize `FEED_CHILD` when the child's hunger or thirst exceeds a critical threshold (e.g., > 70), overriding the caregiver's own needs. | MUST |
+| F3-R6 | Child agents' initial stats (strength, intelligence, sociability) MUST be derived from the parent's stats with a random offset (e.g., `child.str = parent.str ± random(0, 15)`), clamped to [0, 100]. | MUST |
+| F3-R7 | Each child agent MUST have a `maturity_age: int` (in ticks). When `tick_count >= maturity_age`, `is_child` MUST be set to `False`, and `parent_id` MAY be cleared. After maturity, the agent gains full autonomy. | MUST |
+| F3-R8 | If a caregiver dies before the child matures, any nearby adult agent within interaction radius MAY adopt the child (auto-assigned via proximity). If no adult is within radius, the child's stats decay fatally. | MUST |
+
+**F4 — Factions**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F4-R1 | A new `Faction` data model MUST exist with fields: `id` (str), `name` (str), `color` (str, hex), `member_ids` (list[str]), `shared_resources` (dict[str, int]). | MUST |
+| F4-R2 | The `Agent` dataclass MUST gain an optional `faction_id: str | None` field. | MUST |
+| F4-R3 | Faction CRUD MUST be supported: create, delete, join (add member), leave (remove member), and list all factions. | MUST |
+| F4-R4 | The WebSocket snapshot MUST include faction information: each faction's id, name, color, member count, and total shared resources. | MUST |
+| F4-R5 | The frontend canvas MUST render agents with their faction's `color` as a border or overlay when the agent belongs to a faction. | MUST |
+| F4-R6 | When an agent's FSM evaluates trade requests (F5), same-faction agents MUST be preferred (higher acceptance probability in the LLM prompt context). | MUST |
+| F4-R7 | When a faction member dies, their personal inventory MUST be transferred to the faction's `shared_resources`. | MUST |
+
+**F5 — Trading**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F5-R1 | A new `TRADE` action type MUST be added to `ActionType` enum and registered in the action `REGISTRY`. | MUST |
+| F5-R2 | `TRADE` MUST be initiated by one agent (the proposer) targeting another agent within interaction radius (distance ≤ 3 tiles). The proposer specifies `offer: dict[str, int]` (what they give) and `request: dict[str, int]` (what they want). | MUST |
+| F5-R3 | The target agent's LLM MUST receive the trade proposal as context and decide to accept or reject based on the target's current needs, inventory, and relationship with the proposer. | MUST |
+| F5-R4 | If the target accepts, resources MUST be transferred atomically: proposer's inventory debited for `offer`, target's inventory debited for `request`, then both credited with the opposite side. If either side lacks sufficient resources, the trade MUST fail. | MUST |
+| F5-R5 | If the target rejects (or the LLM call times out), neither agent's inventory is modified. The rejection MUST be logged as a SimEvent. | MUST |
+| F5-R6 | A successful trade MUST increment the `interaction_count` between both agents (for F8 relationship tracking). | MUST |
+
+**F6 — Socialization and Conversations**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F6-R1 | A new `SOCIALIZE` action type MUST be added. The action is triggered automatically when two agents are within interaction radius (≤ 3 tiles). | MUST |
+| F6-R2 | Each agent MUST have a `conversation_queue: list[Message]` (FIFO, max 50 messages). Each `Message` contains: `sender_id`, `content` (structured dict), and `tick`. | MUST |
+| F6-R3 | When a proximity encounter is detected, a `Message` is enqueued in both agents' queues. The message content describes the encounter (e.g., `{"type": "greeting", "agent_name": "Alice"}`). | MUST |
+| F6-R4 | On each tick, an agent in IDLE state with non-empty `conversation_queue` MUST process the next message in its LLM prompt. The LLM decides how to respond (reply, share knowledge, ignore, propose trade, etc.). | MUST |
+| F6-R5 | Agents MAY share knowledge from their `knowledge` store (F2) through conversation. When an agent shares a known property, the receiving agent's `knowledge` store MUST be updated. | MUST |
+| F6-R6 | Each successful conversation interaction MUST increment the `interaction_count` for both participants, feeding into F8's relationship system. | MUST |
+| F6-R7 | All conversation events (initiation, messages, knowledge shared) MUST be recorded as SimEvents in the event log with type `"socialize"`. | MUST |
+| F6-R8 | To prevent tick-loop spam, a maximum of 5 conversation pairs per tick MUST be processed. Additional pending pairs are deferred to the next tick. | MUST |
+
+**F7 — Colony Information Panel**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F7-R1 | A new REST endpoint `GET /api/colony` MUST return colony-level statistics: total population, births count (agents spawned this session), deaths count, alive/dead ratio, distribution by role, sex, age groups, total resources across all agents, and active factions list. | MUST |
+| F7-R2 | The WebSocket snapshot MUST be extended with a `colony_stats` field containing a subset of frequently-changing metrics: population, births, deaths, and total resources. | MUST |
+| F7-R3 | A new `ColonyInfo.svelte` component MUST be created in the frontend that displays: population (total, births, deaths), demographic breakdown (role/age distribution as simple bars or table), total resources, and active factions. | MUST |
+| F7-R4 | The ColonyInfo panel MUST auto-refresh from the WebSocket snapshot data (no polling). The REST endpoint serves as the initial load and for detailed data not in the snapshot. | MUST |
+| F7-R5 | The frontend HUD MUST show key colony metrics as minimal widgets: population count, births this session, deaths this session. | MUST |
+
+**F8 — Relationship-Based Reproduction**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F8-R1 | The `Agent` dataclass MUST gain a `relationships: dict[str, RelationshipData]` field where the key is another agent's ID. `RelationshipData` contains: `interaction_count` (int), `last_interaction_tick` (int), and `score` (float, -1.0 to 1.0). | MUST |
+| F8-R2 | Every interaction (trade, conversation, shared-resource use) increments `interaction_count` for both agents and updates `score` based on interaction type (positive for trade/gift, neutral for conversation, negative for theft/conflict). | MUST |
+| F8-R3 | The `REPRODUCE` action MUST be gated by a configurable `INTERACTION_THRESHOLD` (default: 5). The agent's `_find_reproduction_partner()` method MUST only consider agents with `interaction_count >= INTERACTION_THRESHOLD`. | MUST |
+| F8-R4 | Relationship scores MUST decay over time: if `current_tick - last_interaction_tick > DECAY_INTERVAL` (e.g., 100 ticks), `interaction_count` decrements by 1 each additional tick (minimum 0). | MUST |
+| F8-R5 | The AgentInspector panel in the frontend MUST display a "Relationships" section listing each known agent's name, interaction count, and relationship score. | MUST |
+| F8-R6 | Relationship data MUST be included in the WebSocket snapshot per-agent so the frontend can render it. | MUST |
+| F8-R7 | Relationship-aware reproduction MUST replace the current unconditional reproduction logic. Agents with zero interactions MUST NOT be able to reproduce. | MUST |
+
+#### Scenarios
+
+**F1 — LLM-Triggered Action Feedback**
+
+- GIVEN an agent that just completed a `CHOP` action with `ActionResult(success=True, stat_deltas={"energy": -10}, inventory_deltas={"wood": +3})` WHEN the agent enters `LLM_TRIGGER` state THEN the LLM prompt includes `last_action_result: {type: "CHOP", success: true, effects: "energy:-10, wood:+3"}`
+- GIVEN a newly spawned agent with no prior action WHEN it enters `LLM_TRIGGER` for the first time THEN `last_action_result` is `null`/`None`
+- GIVEN an agent whose LLM call fails (timeout) WHEN FSM processes the failed future THEN the agent falls back to instinct behavior and `last_action_result` is NOT accumulated for the next LLM call
+- GIVEN an agent that completed a `DRINK` action (thirst satisfied) WHEN LLM prompt is built THEN the `last_action_result` includes the thirst change and the resource tile consumed
+
+**F2 — Limited Perception / Knowledge**
+
+- GIVEN a world with `POISONOUS_BERRY` subtype (hidden: `{"is_poisonous": true}`) WHEN an agent receives the world snapshot THEN the tile shows `resource_type="BERRY", subtype="POISONOUS_BERRY"` but does NOT include `is_poisonous`
+- GIVEN an agent consumes a `POISONOUS_BERRY` (EAT action) WHEN the action completes THEN the agent's `knowledge["POISONOUS_BERRY"]["is_poisonous"]` is `True`, and the agent loses health
+- GIVEN an agent with `knowledge={"POISONOUS_BERRY": {"is_poisonous": True}}` WHEN the LLM is queried about what to eat THEN the knowledge is included as context: "You know POISONOUS_BERRY is poisonous"
+- GIVEN Agent A knows `POISONOUS_BERRY` is poisonous and Agent B does NOT WHEN Agent A shares this knowledge via conversation THEN Agent B's `knowledge["POISONOUS_BERRY"]["is_poisonous"]` is set to `True`
+
+**F3 — Childhood and Parental Care**
+
+- GIVEN a newborn agent WHEN created THEN `is_child=True`, `parent_id` is set, and the agent spawns on a tile adjacent to the parent
+- GIVEN a child agent with hunger=90 (critical) WHEN its FSM ticks THEN the action is NOT EAT/DRINK — the child waits; the parent's FSM triggers `FEED_CHILD` instead
+- GIVEN a parent executes `FEED_CHILD(child_id)` with `inventory={"berry": 5}` WHEN the action completes THEN the child's hunger decreases by 30 and the parent's inventory decreases by 1 berry
+- GIVEN child agent with parent stats `strength=70, intelligence=50, sociability=30` WHEN the child is spawned THEN its stats are within `[55-85], [35-65], [15-45]` respectively (parent ±15)
+- GIVEN a child agent with `maturity_age=500` WHEN `tick_count >= 500` THEN `is_child=False` and the agent can independently eat/drink
+- GIVEN a caregiver agent dies while a child is still dependent WHEN the tick loop checks for adopters THEN a nearby adult within 3 tiles is assigned as new caregiver; if none exists, the child's health decays each tick until death
+
+**F4 — Factions**
+
+- GIVEN a faction with `color="#FF0000"` WHEN a member agent is rendered in the frontend canvas THEN the agent has a red border/overlay
+- GIVEN a faction member dies WHEN death is processed THEN the agent's inventory is transferred to the faction's `shared_resources`
+- GIVEN two agents in the same faction WHEN one proposes a trade THEN the LLM prompt includes context that they are faction allies, increasing acceptance likelihood
+- GIVEN a faction with 3 members WHEN queried via GET /api/factions THEN the response includes id, name, color, member_count=3, and shared_resources
+
+**F5 — Trading**
+
+- GIVEN Agent A at (10,10) and Agent B at (11,10) within interaction radius WHEN Agent A initiates TRADE with offer={"wood": 3} and request={"berry": 5} THEN the trade proposal is added to Agent B's conversation queue
+- GIVEN Agent B receives a trade proposal and its LLM accepts WHEN the trade is processed THEN Agent A loses 3 wood, Agent B loses 5 berry, Agent A gains 5 berry, Agent B gains 3 wood (atomic swap)
+- GIVEN Agent A has offer={"wood": 10} but only has 3 wood in inventory WHEN the trade is evaluated THEN the action fails with `success=False` and neither inventory is modified
+- GIVEN a successful trade between Agent A and Agent B WHEN the trade completes THEN both agents' `interaction_count` increments by 1
+
+**F6 — Socialization and Conversations**
+
+- GIVEN two agents within distance ≤ 3 tiles WHEN the proximity check runs THEN a `Message` is enqueued in both agents' `conversation_queue`
+- GIVEN an agent in IDLE state with `conversation_queue` containing 3 messages WHEN the FSM ticks THEN the agent processes the oldest message, the LLM receives the message context and produces a response plan
+- GIVEN Agent A shares knowledge about `POISONOUS_BERRY` via a conversation message WHEN Agent B processes the message THEN Agent B's `knowledge` store is updated with the shared information
+- GIVEN a conversation event WHEN it occurs THEN a SimEvent with type `"socialize"` is logged containing both agent IDs and message summary
+- GIVEN more than 5 conversation pairs are pending in a single tick WHEN the tick processes social interactions THEN only 5 pairs are processed and the remainder are deferred to the next tick
+
+**F7 — Colony Information Panel**
+
+- GIVEN a running simulation with 10 agents (3 births, 1 death) WHEN `GET /api/colony` is called THEN the response includes `population=9`, `births=3`, `deaths=1`, `alive=9`, `dead=1`, plus resource totals and faction list
+- GIVEN a WebSocket snapshot is broadcast WHEN the `colony_stats` field is present THEN the frontend ColonyInfo panel updates without additional API calls
+- GIVEN ColonyInfo.svelte is mounted and receives colony stats via the store WHEN stats change THEN the display auto-updates via Svelte 5 reactivity
+
+**F8 — Relationship-Based Reproduction**
+
+- GIVEN Agent A and Agent B have `interaction_count=0` WHEN Agent A's FSM evaluates reproduction partners THEN `_find_reproduction_partner()` returns `None`
+- GIVEN Agent A and Agent B have `interaction_count=7` (≥ threshold=5) WHEN Agent A's FSM evaluates reproduction partners THEN `_find_reproduction_partner()` returns Agent B's ID as a candidate
+- GIVEN two agents with `last_interaction_tick=100` at tick 300 WHEN the decay check runs THEN `interaction_count` has decremented by `floor((300-100)/DECAY_INTERVAL)` (minimum 0)
+- GIVEN the AgentInspector panel WHEN an agent has 2 relationships THEN the panel shows a "Relationships" section listing both agents with their interaction count and score
+- GIVEN an agent's relationships include Agent B with `score=0.8` WHEN Agent A evaluates trade with Agent B THEN the LLM receives the positive relationship score as favorable context
+
+#### Acceptance Criteria
+
+- [ ] **F1**: An action's result (success/failure, stat changes, inventory changes) appears in the next LLM prompt as `last_action_result`. First-tick agents gracefully pass `null`. LLM timeouts fall back to instincts and do NOT accumulate stale context.
+- [ ] **F2**: Resource subtypes have hidden properties not visible in the world snapshot. Agents learn properties by consuming the resource. Knowledge is per-agent (not shared globally). Knowledge is shareable via conversation. The LLM prompt includes known knowledge about resources.
+- [ ] **F3**: Newborn agents are born adjacent to parent with `is_child=True`. Children cannot EAT/DRINK independently — the caregiver's FSM triggers FEED_CHILD. Stats are inherited with random offset. Children mature at `maturity_age` ticks. Orphaned children are adopted by nearest adult or die if none exists.
+- [ ] **F4**: Faction CRUD works. Agents show faction color in the canvas. Agent death transfers inventory to faction shared pool. Same-faction members get trade preference via LLM context.
+- [ ] **F5**: TRADE action works between nearby agents. Proposer specifies offer/request. Target LLM evaluates and accepts/rejects. Accepted trades execute atomically. Rejected trades log without inventory changes. Successful trades increment interaction counts.
+- [ ] **F6**: Proximity-based conversations trigger automatically. Messages are enqueued FIFO (max 50). LLM processes messages during the next planning cycle. Knowledge is shared via conversation messages. Interaction counts increment. Events are logged. Cap of 5 conversation pairs per tick enforced.
+- [ ] **F7**: `GET /api/colony` returns demographics and resource totals. WebSocket snapshot includes `colony_stats`. ColonyInfo.svelte renders population, births, deaths, resource totals, and factions. Frontend HUD shows key metric widgets.
+- [ ] **F8**: `relationships` dict tracks interactions per agent pair. REPRODUCE is gated by `interaction_count >= INTERACTION_THRESHOLD`. Relationships decay over time without interaction. AgentInspector shows relationships. Unconditional reproduction is replaced.
+- [ ] **Backward compatibility**: All existing simulation-engine tests pass without modification. Existing agents without `faction_id`, `is_child`, `knowledge`, or `relationships` continue to function with default values.
+- [ ] **Performance**: Tick loop with all social features active (20 agents, 3 factions, conversations, trades) completes within 150ms per tick on reference hardware.

--- a/openspec/changes/archive/agent-society/tasks.md
+++ b/openspec/changes/archive/agent-society/tasks.md
@@ -1,0 +1,1253 @@
+# Tasks: agent-society
+
+> 8 features, 5 fases, 28 tareas. Orden de implementación estricto por dependencias.
+
+---
+
+## Resumen
+
+| Fase | Features | Tareas | Depende de | Estimación total |
+|------|----------|--------|------------|-----------------|
+| F1 — Foundation | F1 (LLM feedback), F8 (Relationships) | T1–T6 | Ninguna | Alta |
+| F2 — Social Core | F6 (Conversations) | T7–T10 | F1 | Alta |
+| F3 — Society | F2 (Knowledge), F5 (Trading) | T11–T17 | F2 | Alta |
+| F4 — Lifecycle & Groups | F3 (Childhood), F4 (Factions) | T18–T23 | F3 | Alta |
+| F5 — Colony UI | F7 (Colony panel) + frontend | T24–T28 | F4 | Media |
+
+---
+
+## Fase 1 — Foundation (F1: Action Feedback + F8: Relationships)
+
+### T1 — Añadir `action_type` y `action_summary` a `ActionResult`
+**Feature**: F1
+**Fase**: 1
+**Archivos**: `backend/app/simulation/actions.py`
+**Depende de**: Ninguna
+**Estimación**: Baja
+
+**Descripción**:
+Añadir dos nuevos campos al dataclass `ActionResult` en `actions.py`:
+- `action_type: ActionType | None = None`
+- `action_summary: str = ""` — string con resumen de deltas, ej. `"hunger:-30, wood:+5, berries:-1"`
+
+Actualizar **todos los handlers existentes** (`handle_move`, `handle_chop`, `handle_drink`, `handle_eat`, `handle_gather`, `handle_rest`, `handle_reproduce`) para que poblén ambos campos. El `action_summary` debe incluir los cambios de estado y de inventario que el handler produce. Ejemplo para `handle_eat`: `action_summary="hunger:-20, berries:-1"`.
+
+Actualizar la constante `ACTION_EMOJIS` no requiere cambio.
+
+**Criterios de aceptación**:
+- [x] `ActionResult` tiene campos `action_type` y `action_summary` con valores por defecto `None` / `""`
+- [x] `handle_eat()` produce `ActionResult(action_type=ActionType.EAT, action_summary="hunger:-20, berries:-1")`
+- [x] `handle_chop()` produce `action_summary` con `wood:+1`
+- [x] `handle_move()` produce `action_summary` con cambios de posición si aplica
+- [x] `handle_drink()` produce `action_summary` con `thirst:0`
+- [x] `handle_gather()` produce `action_summary` con el recurso recolectado
+- [x] `handle_rest()` produce `action_summary` con `energy:+10`
+- [x] `handle_reproduce()` produce `action_summary` informativo
+- [x] Todos los tests existentes de `TestActions` siguen pasando
+
+---
+
+### T2 — Añadir `last_action_result` al `Agent` y propagarlo al prompt LLM
+**Feature**: F1
+**Fase**: 1
+**Archivos**: `backend/app/simulation/agent.py`, `backend/app/simulation/engine.py`, `backend/app/ai/orchestrator.py`, `backend/app/ai/prompts.py`
+**Depende de**: T1
+**Estimación**: Media
+
+**Descripción**:
+1. **Agent** (`agent.py`): Añadir `last_action_result: Optional[ActionResult] = None` al dataclass `Agent`.
+2. **Engine** (`engine.py`):
+   - En `_fsm_executing()`: después de ejecutar un handler y obtener el `ActionResult`, asignarlo a `agent.last_action_result = result`.
+   - En `_fsm_llm_trigger()`: antes de construir el prompt, leer `agent.last_action_result`. Si existe, pasarlo como nuevo parámetro a `build_prompt()`. Después del prompt, resetear `agent.last_action_result = None` (evitar acumulación de contexto stale).
+   - En fallback de instinto (LLM timeout en `_fsm_llm_waiting`): si el agente cae a instinto, el `last_action_result` pendiente debe descartarse (no acumularse).
+3. **MockLLMOrchestrator** (`agent.py`): Actualizar `build_prompt()` para aceptar y formatear `last_action_result`.
+4. **RealLLMOrchestrator** (`orchestrator.py`): Actualizar `build_prompt()` para pasar `last_action_result` al template de prompt.
+5. **Prompts** (`prompts.py`): Añadir una nueva sección `LAST ACTION RESULT:` en el prompt template, con el formato:
+   ```
+   LAST ACTION RESULT:
+   - Action: {action_type}
+   - Success: {true/false}
+   - Effects: {action_summary}
+   ```
+   Si `last_action_result` es `None`, la sección debe decir `LAST ACTION RESULT: None (first tick)`.
+
+**Criterios de aceptación**:
+- [x] Nuevo agente (primer tick) tiene `last_action_result=None` y el prompt muestra "None (first tick)"
+- [x] Después de una acción, `ActionResult` queda asignado en `agent.last_action_result`
+- [x] `build_prompt()` incluye la sección `LAST ACTION RESULT` con action_type, success y summary
+- [x] Después de construir el prompt, `agent.last_action_result` es `None` (consumido)
+- [x] En fallback de instinto por timeout, el `last_action_result` se descarta sin acumular
+- [x] Tests `test_action_result_captured`, `test_action_result_null_on_first_tick`, `test_action_result_cleared_after_read` pasan
+
+---
+
+### T3 — Añadir `RelationshipData` y campo `relationships` al `Agent`
+**Feature**: F8
+**Fase**: 1
+**Archivos**: `backend/app/simulation/agent.py`, `backend/app/models/schemas.py`, `backend/app/simulation/snapshot.py`
+**Depende de**: Ninguna
+**Estimación**: Baja
+
+**Descripción**:
+1. **Agent** (`agent.py`): Añadir nuevo dataclass `RelationshipData` con campos:
+   - `interaction_count: int = 0`
+   - `last_interaction_tick: int = 0`
+   - `score: float = 0.0` (rango -1.0 a 1.0)
+
+   Añadir campo `relationships: dict[str, RelationshipData] = field(default_factory=dict)` al dataclass `Agent`.
+
+2. **AgentState schema** (`schemas.py`): Añadir campo `relationships: dict[str, dict] = {}` al modelo Pydantic `AgentState`. Convertir `RelationshipData` a dict plano para serialización.
+
+3. **Snapshot builder** (`snapshot.py`): Actualizar `_build_agent_state()` para incluir `agent.relationships` serializado como dict de dicts.
+
+4. **AgentFactory** (`agent.py`): No requiere cambios — `relationships` tiene default factory.
+
+**Criterios de aceptación**:
+- [x] `RelationshipData` existe con los 3 campos requeridos
+- [x] `Agent.relationships` es un dict vacío por defecto
+- [x] `AgentState.relationships` se serializa correctamente en el snapshot
+- [x] Snapshot incluye `relationships` para cada agente (aunque vacío)
+- [x] Agentes existentes sin relaciones funcionan con valor por defecto (backward compat)
+
+---
+
+### T4 — Implementar tracking de relaciones por interacciones
+**Feature**: F8
+**Fase**: 1
+**Archivos**: `backend/app/simulation/engine.py`, `backend/app/simulation/actions.py`
+**Depende de**: T3
+**Estimación**: Media
+
+**Descripción**:
+1. **Engine** (`engine.py`):
+   - Añadir constantes:
+     - `INTERACTION_THRESHOLD = 5` (en `REPRODUCE_COOLDOWN` y similares)
+     - `DECAY_INTERVAL = 100`
+   - Crear método `_update_relationship(agent_a: Agent, agent_b: Agent, tick: int, score_delta: float = 0.1)` que:
+     - Incrementa `interaction_count` para ambos
+     - Actualiza `last_interaction_tick` para ambos
+     - Aplica `score_delta` al `score` de ambos (clamped a [-1.0, 1.0])
+   - En `_process_needs()`: añadir lógica de decaimiento de relaciones:
+     - Por cada agente, por cada relación: si `tick - last_interaction_tick > DECAY_INTERVAL`, decrementar `interaction_count` en 1 (mínimo 0).
+   - En `handle_reproduce` (cuando se completa exitosamente): llamar a `_update_relationship` con `score_delta=0.2`.
+
+2. **Actions** (`actions.py`):
+   - `handle_reproduce()`: tras reproducción exitosa (llamada desde engine), actualizar relaciones de ambos padres.
+
+**Criterios de aceptación**:
+- [x] `_update_relationship()` actualiza ambos agentes con interaction_count +1
+- [x] `score` no excede el rango [-1.0, 1.0]
+- [x] Después de `DECAY_INTERVAL` ticks sin interacción, `interaction_count` decrementa
+- [x] `interaction_count` nunca es menor que 0
+- [x] Tests `test_relationship_data`, `test_relationship_decay` pasan
+
+---
+
+### T5 — Gatear `REPRODUCE` por threshold de interacciones
+**Feature**: F8
+**Fase**: 1
+**Archivos**: `backend/app/simulation/engine.py`
+**Depende de**: T4
+**Estimación**: Media
+
+**Descripción**:
+Modificar `_find_reproduction_partner()` en `engine.py` para que:
+1. Solo considere agentes que tengan `agent.relationships[other.id].interaction_count >= INTERACTION_THRESHOLD` (5).
+2. Si un agente no tiene entradas en `relationships` para el candidato, se considera 0 interacciones → no apto.
+3. Mantener las demás comprobaciones existentes (sexo opuesto, energía > 20, hambre/sed < 80, edad mínima, distancia).
+4. Añadir logging warning cuando un agente intenta reproducir pero no hay pareja válida por falta de interacciones.
+
+Modificar `_fsm_evaluate()`: la sección de reproducción (punto 6) debe verificar que exista un partner viable antes de transicionar a `executing` con acción reproduce. Si no hay partner (por threshold), pasar a LLM directamente.
+
+Eliminar la lógica actual que permite reproducción sin restricción de interacciones.
+
+**Criterios de aceptación**:
+- [x] `_find_reproduction_partner()` retorna `None` si `interaction_count < INTERACTION_THRESHOLD` para todos los candidatos
+- [x] Si `interaction_count >= 5`, el agente es candidato válido (si cumple demás condiciones)
+- [x] Agentes con 0 interacciones nunca son considerados para reproducción
+- [x] Tests `test_reproduce_gated_by_interactions` pasa
+- [x] Se reemplaza la lógica de reproducción incondicional actual
+
+---
+
+### T6 — Tests de Fase 1 (F1 + F8)
+**Feature**: F1, F8
+**Fase**: 1
+**Archivos**: `backend/tests/test_engine.py` (o nuevo `backend/tests/test_social.py`)
+**Depende de**: T1, T2, T3, T4, T5
+**Estimación**: Baja
+
+**Descripción**:
+Implementar todos los tests unitarios para F1 y F8 según el plan de testing del design:
+
+**F1 Tests:**
+- `test_action_result_captured` — Crear ActionResult, asignar a agente, verificar que `build_prompt()` lo incluye
+- `test_action_result_null_on_first_tick` — Agente nuevo → `last_action_result` es None
+- `test_action_result_cleared_after_read` — Después de construir prompt, verificar field es None
+- `test_action_result_llm_timeout_discard` — Timeout de LLM → last_action_result se descarta
+
+**F8 Tests:**
+- `test_relationship_data` — Interacción entre agentes → relación creada con campos correctos
+- `test_reproduce_gated_by_interactions` — interaction_count < threshold → no partner
+- `test_relationship_decay` — Después de decay interval, interaction_count decrementa
+
+**Estrategia de mocks:**
+- Usar `MockLLMOrchestrator(success_rate=1.0, delay_range=(0.01, 0.05))` para tests deterministas
+- Crear agentes directamente con `Agent(...)` para tests unitarios
+- Usar engine real para tests de integración con tick loop
+
+---
+
+## Fase 2 — Social Core (F6: Socialización y Conversaciones)
+
+### T7 — Crear `Message` dataclass y `ConversationManager`
+**Feature**: F6
+**Fase**: 2
+**Archivos**: `backend/app/simulation/conversation.py` (NUEVO)
+**Depende de**: Fase 1 (T4)
+**Estimación**: Media
+
+**Descripción**:
+Crear nuevo módulo `backend/app/simulation/conversation.py` con:
+
+1. **`Message` dataclass:**
+   ```python
+   @dataclass
+   class Message:
+       sender_id: str
+       content: dict  # structured: {"type": "greeting"|"share_knowledge"|"trade_proposal"|...}
+       tick: int
+   ```
+
+2. **`ConversationManager` class:**
+   - `max_pairs_per_tick: int = 5`
+   - `max_queue_size: int = 50`
+   - `_pending_pairs: list[tuple[str, str]]` — pares de agentes pendientes para procesar
+   - `detect_encounters(agents: list[Agent], radius: float, tick: int) -> None`:
+     - Reutiliza lógica O(n²) de `check_proximity_encounters()`
+     - Para cada par dentro de radio, enqueuea un `Message` de tipo `"greeting"` en ambos agentes
+     - Si hay más de `max_pairs_per_tick`, difiere el resto a `_pending_pairs`
+     - Cada `Message.content` incluye: `{"type": "greeting", "agent_name": "..."}`
+   - `process_next_pair(agent_a, agent_b, world) -> tuple[Message, Message] | None`:
+     - Toma el siguiente par pendiente
+     - Enqueuea los mensajes de encuentro en cada agente
+     - Retorna los mensajes creados o None si no hay pares
+   - Método interno `_enqueue_message(agent, message)` que respeta `max_queue_size` (FIFO, si excede, descarta el más antiguo)
+
+Registrar el módulo en `backend/app/simulation/__init__.py`.
+
+**Criterios de aceptación**:
+- [x] `Message` dataclass con sender_id, content (dict), tick
+- [x] `detect_encounters()` encuentra pares dentro de radio y enqueuea greeting messages
+- [x] Se respeta `max_pairs_per_tick=5`; pares excedentes se difieren
+- [x] Cada agente tiene max 50 mensajes en cola (FIFO discard)
+- [x] Tests `test_conversation_enqueue`, `test_max_queue_size`, `test_max_pairs_per_tick` pasan
+
+---
+
+### T8 — Integrar `conversation_queue` en el Agent y el tick del engine
+**Feature**: F6
+**Fase**: 2
+**Archivos**: `backend/app/simulation/agent.py`, `backend/app/simulation/engine.py`, `backend/app/simulation/conversation.py`
+**Depende de**: T7
+**Estimación**: Alta
+
+**Descripción**:
+
+1. **Agent** (`agent.py`): Añadir `conversation_queue: list[Message] = field(default_factory=list)` al dataclass `Agent`. Necesita importar `Message` desde `conversation.py` — usar `TYPE_CHECKING` para evitar circular imports.
+
+2. **Engine** (`engine.py`):
+   - En `__init__()`: instanciar `self.conversation_manager = ConversationManager()`.
+   - Crear nuevo método `async _process_social_interactions(tick: int)`:
+     1. Llamar a `self.conversation_manager.detect_encounters(self.agents, INTERACTION_RADIUS, tick)`.
+     2. Procesar pares pendientes hasta `max_pairs_per_tick`.
+     3. Para cada agente con `conversation_queue` no vacía en estado IDLE, marcar para que el FSM lo procese.
+     4. Enqueuear SimEvents de tipo `"socialize"` para cada conversación.
+   - Reordenar el tick loop (`_tick()`) a:
+     ```
+     1. _process_needs(tick)
+     2. _run_agent_fsm() para cada agente
+     3. _process_social_interactions(tick)       # NUEVO
+     4. event_queue.drain()
+     5. _poll_llm_responses(tick)
+     6. world.regenerate_resources()
+     7. check_proximity_encounters() (existente)
+     8. check_resource_discoveries() (existente)
+     9. Build + broadcast snapshot
+     ```
+   - En `_process_social_interactions()`: para cada agente cuyo FSM esté en `evaluate` y tenga `conversation_queue` no vacía, incluir los mensajes como contexto adicional.
+
+3. **Faction deaths**: NO mover `_process_faction_agent_death` aún (se hará en F4, fase 4).
+
+4. **SimEvent types**: Añadir `"socialize"` a la lista válida de tipos de eventos.
+
+**Criterios de aceptación**:
+- [x] Agent tiene campo `conversation_queue: list[Message]` con default factory
+- [x] Engine instancia `ConversationManager`
+- [x] `_process_social_interactions()` se llama cada tick y enqueuea mensajes
+- [x] Se respeta límite de 5 pares por tick
+- [x] Evento `"socialize"` se logea correctamente
+- [x] Tests de integración F6 pasan (conversación fluye a través del tick)
+
+---
+
+### T9 — Actualizar prompt LLM con contexto social y procesar acciones sociales
+**Feature**: F6
+**Fase**: 2
+**Archivos**: `backend/app/ai/prompts.py`, `backend/app/ai/orchestrator.py`, `backend/app/simulation/engine.py`
+**Depende de**: T8
+**Estimación**: Media
+
+**Descripción**:
+
+1. **Prompt template** (`prompts.py`):
+   - Añadir nueva sección `SOCIAL CONTEXT:` después de `NEARBY AGENTS`:
+   ```
+   SOCIAL CONTEXT:
+   - Unread messages: {count}
+   - Latest: {snippet}
+   ```
+   - Añadir `"socialize"` y `"trade"` como acciones válidas en `JSON_FORMAT_INSTRUCTION`.
+   - Añadir `"feed_child"` como acción válida (prepara para F3).
+
+2. **Orchestrator** (`orchestrator.py`):
+   - En `RealLLMOrchestrator.build_prompt()`: leer `agent.conversation_queue` (primeros 3 mensajes como snippet), formatearlos, pasarlos al prompt builder.
+   - En `MockLLMOrchestrator.build_prompt()`: mismo cambio (para testing).
+
+3. **Engine FSM** (`engine.py`):
+   - En `_fsm_evaluate()`: antes de evaluar necesidades, si el agente tiene `conversation_queue` no vacía y está en `evaluate`, procesar el mensaje más antiguo:
+     - Si es `greeting`: continuar a LLM con contexto social (no requiere acción especial).
+     - Si es `share_knowledge`: actualizar `agent.knowledge` (prepara para F2).
+     - Si es `trade_proposal`: marcar para que el LLM lo evalúe (prepara para F5).
+   - Añadir transición: en `evaluate`, si hay mensajes en cola Y no hay necesidad crítica, ir a `llm_trigger` para que el LLM decida cómo responder.
+
+4. **Añadir estado FSM** `"social_interaction"`: (opcional, si se justifica). El design sugiere un estado dedicado, pero por simplicidad podemos procesar en `evaluate`. Decisión del implementador.
+
+**Criterios de aceptación**:
+- [x] Prompt incluye sección SOCIAL CONTEXT con count de mensajes no leídos
+- [x] JSON format instructions incluyen "socialize", "trade", "feed_child"
+- [x] Agent con conversación pendiente recibe contexto social en el prompt
+- [x] Messages de tipo greeting se procesan y generan SimEvent
+- [x] Tests F6 (LLM procesa mensajes de conversación) pasan
+
+---
+
+### T10 — Tests de Fase 2 (F6)
+**Feature**: F6
+**Fase**: 2
+**Archivos**: `backend/tests/test_social.py` (NUEVO)
+**Depende de**: T7, T8, T9
+**Estimación**: Baja
+
+**Descripción**:
+Implementar todos los tests unitarios y de integración para F6:
+
+**Unit tests:**
+- `test_conversation_enqueue` — Dos agentes dentro de radio → messages en ambas colas
+- `test_max_queue_size` — 60 mensajes → solo últimos 50 retenidos
+- `test_max_pairs_per_tick` — 10 pares pendientes → 5 procesados, 5 diferidos
+- `test_socialize_event_logged` — Conversación genera SimEvent type "socialize"
+
+**Integration tests:**
+- `test_social_tick_integration` — Engine tick completo con conversaciones entre agentes
+- `test_conversation_prompt_context` — Agent con cola no vacía → prompt incluye contexto social
+
+**Mock strategy:**
+- Usar `MockLLMOrchestrator` para simular respuestas LLM
+- Agentes con posición controlada para garantizar encuentros por proximidad
+
+---
+
+## Fase 3 — Society (F2: Percepción + F5: Trading)
+
+### T11 — Añadir `subtype` y `hidden_properties` a `Tile` y actualizar generación del mundo
+**Feature**: F2
+**Fase**: 3
+**Archivos**: `backend/app/simulation/world.py`, `backend/app/models/schemas.py`, `backend/app/simulation/snapshot.py`
+**Depende de**: Ninguna (independiente de Fase 2)
+**Estimación**: Media
+
+**Descripción**:
+
+1. **Tile** (`world.py`):
+   - Añadir campos:
+     - `subtype: str | None = None` — ej. "POISONOUS_BERRY", "SAFE_BERRY", "OAK_TREE", "PINE_TREE"
+     - `hidden_properties: dict[str, Any] = field(default_factory=dict)` — ej. `{"is_poisonous": True}`
+   - Definir diccionario `RESOURCE_SUBTYPES` que mapee resource_type → lista de subtipos con sus hidden_properties:
+     ```python
+     RESOURCE_SUBTYPES = {
+         "berries": [
+             {"name": "SAFE_BERRY", "hidden": {}, "weight": 70},
+             {"name": "POISONOUS_BERRY", "hidden": {"is_poisonous": True}, "weight": 30},
+         ],
+         "tree": [
+             {"name": "OAK_TREE", "hidden": {"wood_quality": "strong"}, "weight": 50},
+             {"name": "PINE_TREE", "hidden": {"wood_quality": "light"}, "weight": 50},
+         ],
+     }
+     ```
+
+2. **World generation** (`world.py`):
+   - En `_place_resource()` o post-generación: asignar `subtype` y `hidden_properties` aleatoriamente según los weights definidos.
+   - No todos los recursos necesitan subtype — agua y stone pueden no tenerlo (o tenerlo opcional).
+
+3. **TileUpdate schema** (`schemas.py`):
+   - Añadir campo opcional `subtype: str | None = None`
+   - **NO** incluir `hidden_properties` — eso es intencional (las propiedades ocultas no son visibles en el snapshot).
+
+4. **Snapshot builder** (`snapshot.py`):
+   - En `_build_agent_state()` y `build()/build_delta()`: incluir `tile.subtype` en los `TileUpdate` pero **NO** `tile.hidden_properties`.
+
+**Criterios de aceptación**:
+- [x] Tile tiene campos `subtype` y `hidden_properties` con defaults seguros
+- [x] Recursos se generan con subtipos según weights definidos
+- [x] TileUpdate schema incluye `subtype` pero NO `hidden_properties`
+- [x] Snapshot del mundo muestra `subtype` pero nunca `hidden_properties`
+- [x] Test `test_tile_with_subtype` y `test_snapshot_does_not_expose_hidden` pasan
+
+---
+
+### T12 — Añadir `knowledge` al Agent y revelar propiedades ocultas al comer
+**Feature**: F2
+**Fase**: 3
+**Archivos**: `backend/app/simulation/agent.py`, `backend/app/simulation/actions.py`, `backend/app/models/schemas.py`, `backend/app/simulation/snapshot.py`
+**Depende de**: T11
+**Estimación**: Media
+
+**Descripción**:
+
+1. **Agent** (`agent.py`): Añadir campo `knowledge: dict[str, dict[str, Any]] = field(default_factory=dict)` al dataclass `Agent`. Key = subtype name, Value = dict de propiedades reveladas.
+
+2. **handle_eat** (`actions.py`):
+   - Modificar `handle_eat()` para que, después de consumir berries:
+     - Si el tile de origen tiene `subtype` y `hidden_properties`:
+       - Revelar: `agent.knowledge[tile.subtype] = dict(tile.hidden_properties)`
+       - Añadir efecto en `action_summary`: `"... learned: POISONOUS_BERRY is poisonous"`
+     - Si no hay subtype, no hay cambio en knowledge.
+   - Nota: `handle_eat()` actualmente reduce hambre usando berries del inventario. Necesitamos saber de qué tile vino la berry. Opción: buscar en `_tiles_on_or_adjacent` un tile con subtype y restar de ahí. Alternativa: el step puede incluir la fuente. Revisar cómo se llama actualmente.
+
+3. **AgentState** (`schemas.py`):
+   - Añadir campo `knowledge: list[str] = []` — lista de nombres de subtipos conocidos (para UI, no el dict completo).
+
+4. **Snapshot builder** (`snapshot.py`):
+   - En `_build_agent_state()`: incluir `knowledge=list(agent.knowledge.keys())` (solo los nombres de subtipos conocidos).
+
+**Criterios de aceptación**:
+- [x] Agent tiene `knowledge: dict` vacío por defecto
+- [x] Consumir un tile con `subtype` y `hidden_properties` → knowledge se actualiza
+- [x] El action_summary incluye el learning (ej. "learned: POISONOUS_BERRY")
+- [x] Dos agentes que comen diferentes cosas tienen knowledge independiente
+- [x] Tests `test_eat_reveals_hidden_properties`, `test_knowledge_is_per_agent` pasan
+
+---
+
+### T13 — Añadir knowledge al prompt LLM
+**Feature**: F2
+**Fase**: 3
+**Archivos**: `backend/app/ai/prompts.py`, `backend/app/ai/orchestrator.py`
+**Depende de**: T12
+**Estimación**: Baja
+
+**Descripción**:
+
+1. **Prompt template** (`prompts.py`):
+   - Añadir nueva sección `KNOWLEDGE:` después de `NEARBY RESOURCES`:
+   ```
+   KNOWLEDGE:
+   - You know: {knowledge_string}
+   ```
+   - Formato: si el agente sabe que POISONOUS_BERRY es peligroso: `"POISONOUS_BERRY is poisonous"`
+   - Si no hay knowledge: `"(you have no special knowledge yet)"`
+
+2. **MockLLMOrchestrator** (`agent.py`): Actualizar `build_prompt()` para incluir knowledge.
+
+3. **RealLLMOrchestrator** (`orchestrator.py`): Actualizar `build_prompt()` para pasar knowledge al template. Extraer de `agent.knowledge` y formatear como string.
+
+**Criterios de aceptación**:
+- [x] Prompt incluye sección KNOWLEDGE con los subtipos conocidos formateados
+- [x] Agente sin knowledge muestra "(you have no special knowledge yet)"
+- [x] Test `test_knowledge_in_prompt` pasa
+
+---
+
+### T14 — Crear acción `TRADE` (ActionType + handler)
+**Feature**: F5
+**Fase**: 3
+**Archivos**: `backend/app/simulation/actions.py`, `backend/app/simulation/engine.py`
+**Depende de**: T2 (ActionResult fields)
+**Estimación**: Media
+
+**Descripción**:
+
+1. **ActionType** (`actions.py`):
+   - Añadir `TRADE = "trade"` al enum `ActionType`.
+   - Añadir `SOCIALIZE = "socialize"` (necesario para F6, pero el enum se define aquí).
+   - Añadir `FEED_CHILD = "feed_child"` (necesario para F3, pero el enum se define aquí).
+
+2. **Handler** `handle_trade()` (`actions.py`):
+   ```python
+   def handle_trade(agent, world, target, step) -> ActionResult:
+       # Validar que proposer tiene offer resources (step["offer"])
+       # Validar que target existe y está cerca
+       # NO ejecutar el swap aquí — solo validar y encolar propuesta
+       # Retornar ActionResult con action_type=TRADE
+       # El swap real se hace en el engine cuando el target acepta
+   ```
+   - `handle_trade()` valida que el proponente tiene los recursos de `offer`.
+   - Enqueuea un `Message` de tipo `{"type": "trade_proposal", "from": proposer.id, "offer": {...}, "request": {...}}` en el conversation_queue del target.
+   - Si el proponente no tiene suficientes recursos, falla con success=False.
+   - Registra el `action_type` y `action_summary`.
+
+3. **REGISTRY** (`actions.py`): Añadir `ActionType.TRADE: handle_trade` al registro.
+
+4. **get_action_duration** (`actions.py`): Añadir duración para `ActionType.TRADE` (ej. 5 ticks).
+
+5. **ACTION_EMOJIS** (`actions.py`): Añadir emoji para trade (ej. "🤝").
+
+6. **Engine** (`engine.py`):
+   - El handler `handle_trade()` solo valida y encola. El engine, en `_process_social_interactions()` o en `_fsm_evaluate()`, debe:
+     - Detectar mensajes `trade_proposal` en la cola del target.
+     - Pasar al LLM del target para decidir accept/reject.
+     - Si accept: ejecutar el swap atómico (debitar offer de proponente, debitar request de target, acreditar ambos).
+     - Si reject/timeout: no-op, loguear SimEvent.
+
+7. **FSM evaluate**: Añadir comprobación: si el agente tiene un `trade_proposal` en su cola, priorizar la decisión sobre el trade (ir a LLM).
+
+**Criterios de aceptación**:
+- [x] `ActionType.TRADE` existe en el enum
+- [x] `handle_trade()` valida recursos y encola propuesta como Message
+- [x] Recursos insuficientes → fail, sin cambios en inventarios
+- [x] `handle_trade()` registra `action_type` y `action_summary` correctamente
+- [x] Tests `test_trade_insufficient_funds` pasa
+
+---
+
+### T15 — Flujo completo de trade: evaluación por LLM y swap atómico
+**Feature**: F5
+**Fase**: 3
+**Archivos**: `backend/app/simulation/engine.py`, `backend/app/simulation/conversation.py`, `backend/app/simulation/actions.py`
+**Depende de**: T14, T8 (conversation_queue en engine)
+**Estimación**: Alta
+
+**Descripción**:
+
+1. **Trade evaluation flow** en `engine.py`:
+   - En `_fsm_evaluate()`: si el agente tiene mensajes `trade_proposal` en su `conversation_queue`:
+     - Ir a `llm_trigger` con contexto de "trade decision needed"
+     - El prompt debe incluir la propuesta: "Agent X wants to trade: give {offer} for {request}"
+     - El LLM responde con `{"action": "accept_trade"}` o `{"action": "reject_trade"}`
+   - Nueva función `_execute_trade(proposer, target, offer, request) -> bool`:
+     - Verifica que ambos aún tienen los recursos (race condition check)
+     - Debita `offer` de proposer, debita `request` de target
+     - Acredita `request` a proposer, acredita `offer` a target
+     - Incrementa `interaction_count` para ambos via `_update_relationship`
+     - Loguea SimEvent `type="trade"` con success=true
+     - Si falla (alguien gastó recursos entremedio), rollback implícito (no hacer nada)
+   - Si el LLM rejecta o timeout: loguear SimEvent `type="trade"` con success=false
+
+2. **Procesamiento en `_process_social_interactions()`**:
+   - Después de detectar encuentros, procesar propuestas de trade pendientes.
+   - Para cada propuesta, verificar si el target ya respondió (tiene un accept/reject en su plan).
+   - Si aceptó: ejecutar swap. Si rechazó: no-op.
+
+3. **Trade proposer flow**:
+   - Proposer ejecuta `handle_trade()` que valida y encola.
+   - En tick siguiente, target procesa y responde.
+   - En tick siguiente, proposer ve el resultado (SimEvent).
+
+4. **Prompt instruction**: Añadir instrucción al JSON format para accept/reject trade:
+   ```json
+   {
+     "decision": "accept" | "reject",
+     "reason": "why"
+   }
+   ```
+
+**Criterios de aceptación**:
+- [x] Target LLM recibe contexto de trade proposal
+- [x] Trade aceptado: swap atómico con ambos inventarios actualizados
+- [x] Trade rechazado: no hay cambios en ningún inventario
+- [x] Trade timeout: se trata como rechazo, no hay cambios
+- [x] SimEvent "trade" se loguea con success=true/false
+- [x] interaction_count se incrementa en trade exitoso
+- [x] Tests `test_trade_atomic_swap`, `test_trade_interaction_count`, integración F5+F6+F8 pasan
+
+---
+
+### T16 — Compartir conocimiento vía conversaciones (F2 + F6)
+**Feature**: F2, F6
+**Fase**: 3
+**Archivos**: `backend/app/simulation/conversation.py`, `backend/app/simulation/engine.py`
+**Depende de**: T12 (knowledge en Agent), T8 (conversation_queue en engine)
+**Estimación**: Media
+
+**Descripción**:
+
+1. **Compartir conocimiento en `_process_social_interactions()`**:
+   - Cuando un agente A y B se encuentran (greeting), el sistema puede generar automáticamente un mensaje `share_knowledge` si A tiene knowledge relevante y B no.
+   - Lógica: si A tiene `knowledge` y B no tiene entrada para alguno de esos subtipos, A comparte uno al azar.
+   - El mensaje `Message.content = {"type": "share_knowledge", "subtype": "POISONOUS_BERRY", "properties": {"is_poisonous": True}}`.
+
+2. **Procesar `share_knowledge` en el receptor**:
+   - En `_fsm_evaluate()` (o en el processing de la cola): cuando un agente tiene un mensaje `share_knowledge`:
+     - Actualizar `agent.knowledge[subtype] = properties`
+     - Loguear SimEvent `type="knowledge_shared"`
+   - Esto no requiere acción LLM — es automático.
+
+3. **Incrementar interaction_count por knowledge share**:
+   - Llamar a `_update_relationship(A, B, tick, score_delta=0.05)` cuando se comparte conocimiento.
+
+**Criterios de aceptación**:
+- [x] Agente A con knowledge y B sin knowledge → A comparte knowledge a B
+- [x] B.knowledge se actualiza con la información compartida
+- [x] SimEvent "knowledge_shared" se loguea
+- [x] interaction_count se incrementa
+- [x] Tests `test_knowledge_share_via_message`, `test_knowledge_shared_via_conversation` pasan
+
+---
+
+### T17 — Tests de Fase 3 (F2 + F5)
+**Feature**: F2, F5
+**Fase**: 3
+**Archivos**: `backend/tests/test_social.py` (añadir a archivo existente de F6 tests)
+**Depende de**: T11, T12, T13, T14, T15, T16
+**Estimación**: Baja
+
+**Descripción**:
+Implementar todos los tests para F2 y F5:
+
+**F2 Tests:**
+- `test_tile_with_subtype` — Crear Tile con subtype+hidden, snapshot NO expone hidden
+- `test_eat_reveals_hidden_properties` — Agent come POISONOUS_BERRY → knowledge poblado
+- `test_knowledge_is_per_agent` — Dos agents, uno come → knowledge difiere
+- `test_knowledge_in_prompt` — Agent con knowledge → string aparece en prompt
+- `test_knowledge_share_via_message` — Actualización directa de knowledge vía Message
+
+**F5 Tests:**
+- `test_trade_atomic_swap` — Ambos tienen suficiente → ambos inventarios actualizados
+- `test_trade_insufficient_funds` — Proponente no tiene recursos → fail, sin cambios
+- `test_trade_interaction_count` — Trade exitoso incrementa interaction_count de ambos
+
+**Integration tests:**
+- `test_knowledge_shared_via_conversation` — Flujo completo conversación → knowledge propagado
+- `test_trade_increments_interaction_count` — Trade completo → interaction_count actualizado
+
+---
+
+## Fase 4 — Lifecycle & Groups (F3: Infancia + F4: Facciones)
+
+### T18 — Añadir campos de infancia al Agent y crear acción `FEED_CHILD`
+**Feature**: F3
+**Fase**: 4
+**Archivos**: `backend/app/simulation/agent.py`, `backend/app/simulation/actions.py`, `backend/app/simulation/engine.py`
+**Depende de**: T2 (ActionResult fields), Fase 2 (conversation_queue)
+**Estimación**: Media
+
+**Descripción**:
+
+1. **Agent** (`agent.py`): Añadir campos:
+   - `is_child: bool = False`
+   - `parent_id: str | None = None`
+   - `maturity_age: int = 500`
+
+2. **AgentState** (`schemas.py`): Añadir:
+   - `is_child: bool = False`
+   - `faction_id: str | None = None` (se añade en T19, pero el schema se actualiza aquí)
+
+3. **Snapshot** (`snapshot.py`): Actualizar `_build_agent_state()` para incluir `is_child` y `parent_id` (si existe).
+
+4. **ActionType** (`actions.py`): Ya se añadió `FEED_CHILD` en T14. Verificar que esté en el enum.
+
+5. **Handler** `handle_feed_child()` (`actions.py`):
+   ```python
+   def handle_feed_child(agent, world, target, step) -> ActionResult:
+       # target = child_id
+       # Buscar child agent en engine (o pasar como parámetro)
+       # Validar: child está dentro de INTERACTION_RADIUS
+       # Validar: caregiver tiene berries en inventario
+       # child.hunger = max(0, child.hunger - 30)
+       # agent.inventory["berries"] -= 1
+       # action_summary incluye child hunger change
+   ```
+   - Necesita acceso al child Agent. El handler recibe el engine o la lista de agentes como parámetro extra. Alternativa: pasar `target` como `(child_id,)` y buscar en `engine.agents`.
+   - **Importante**: `handle_feed_child` debe recibir referencia al engine o a la lista de agentes. Cambiar la firma del handler o añadir un contexto.
+
+6. **REGISTRY** (`actions.py`): Añadir `ActionType.FEED_CHILD: handle_feed_child`.
+
+7. **get_action_duration** y **ACTION_EMOJIS**: Añadir entrada para FEED_CHILD.
+
+**Criterios de aceptación**:
+- [x] Agent tiene `is_child`, `parent_id`, `maturity_age` con defaults seguros
+- [x] `handle_feed_child()` reduce hambre del child en 30 y consume 1 berry del caregiver
+- [x] Child fuera de radio → action falla
+- [x] Caregiver sin berries → action falla
+- [x] Tests `test_feed_child_action` pasa
+
+---
+
+### T19 — Spawn de child junto al padre, gating FSM de childhood, prioridad del caregiver
+**Feature**: F3
+**Fase**: 4
+**Archivos**: `backend/app/simulation/engine.py`
+**Depende de**: T18
+**Estimación**: Alta
+
+**Descripción**:
+
+1. **Child spawning** en `_create_offspring()`:
+   - Modificar para que el nuevo agente nazca con:
+     - `is_child=True`
+     - `parent_id=parent1.id` (el que inició la reproducción, o ambos padres)
+     - `maturity_age=random.randint(300, 700)`
+   - Posición: spawn en tile adyacente al padre (Manhattan distance ≤ 2). Reemplazar la lógica actual de posición promedio.
+     ```python
+     # Buscar tile vacío adyacente a parent1
+     for dx, dy in [(0,0), (1,0), (-1,0), (0,1), (0,-1)]:
+         nx, ny = int(parent1.position[0]) + dx, int(parent1.position[1]) + dy
+         if not self._is_tile_occupied(nx, ny):
+             child.position = (float(nx), float(ny))
+             break
+     ```
+   - Stats heredados: `child.str = parent1.str ± random(0, 15)`, clamp [0, 100]. Usar el padre que inició la reproducción para la herencia primaria.
+
+2. **FSM gating para children** en `_fsm_evaluate()`:
+   - Si `agent.is_child`:
+     - Bloquear EAT y DRINK: si la evaluación llega a los pasos 1-3 (comer/beber), ignorar y pasar directamente a "wait for caregiver" (no hacer nada, transition a idle).
+     - No enviar child a LLM (saltar paso 7). Los children actúan por instinto: solo deambulan (move aleatorio) cerca del padre.
+     - Energía y hambre/sed del child siguen decayendo normalmente.
+
+3. **Caregiver priority** en `_fsm_evaluate()`:
+   - Antes del paso 1 (incluso antes de las necesidades propias), si el agente tiene un child (buscar en `self.agents` donde `parent_id == agent.id`):
+     - Verificar si child.hunger > 70 o child.thirst > 70
+     - Si es crítico: ejecutar `FEED_CHILD(child_id)` como acción prioritaria, incluso por encima de las propias necesidades del caregiver.
+     - El caregiver debe estar cerca del child (INTERACTION_RADIUS). Si no, mover hacia el child primero (pathfinding al child).
+
+4. **Maturity check** en `_process_needs()`:
+   - Por cada child: si `agent.age >= agent.maturity_age`:
+     - `agent.is_child = False`
+     - `agent.parent_id = None` (opcional, se puede mantener para registro)
+     - Loguear SimEvent type="maturity"
+
+**Criterios de aceptación**:
+- [x] Newborn spawns adjacent to parent (Manhattan ≤ 2)
+- [x] Newborn tiene `is_child=True`, `parent_id` seteado, `maturity_age` aleatorio 300-700
+- [x] Stats del child están dentro de [parent ± 15]
+- [x] Child no puede ejecutar EAT o DRINK
+- [x] Caregiver prioriza FEED_CHILD cuando child está crítico (hambre/sed > 70)
+- [x] Al alcanzar maturity_age, is_child=False y child gana autonomía
+- [x] Tests `test_child_blocks_eat`, `test_child_stat_inheritance`, `test_child_maturity`, `test_child_spawn_adjacent_to_parent` pasan
+
+---
+
+### T20 — Sistema de adopción de huérfanos
+**Feature**: F3
+**Fase**: 4
+**Archivos**: `backend/app/simulation/engine.py`, `backend/app/simulation/event_queue.py`
+**Depende de**: T19
+**Estimación**: Media
+
+**Descripción**:
+
+1. **Death handler** en `_process_needs()`:
+   - Cuando un agente muere, antes de removerlo de `self.agents`:
+     - Buscar en `self.agents` si algún child tiene `parent_id == dead_agent.id`
+     - Si hay dependientes:
+       - Buscar el adulto más cercano dentro de `INTERACTION_RADIUS` que no sea el fallecido
+       - Si existe: reasignar `child.parent_id = new_caregiver.id`
+       - Loguear SimEvent `type="adoption"` con descripción "X adopted Y after Z died"
+       - Si no existe adulto cercano: el child se queda sin caregiver. Su salud decae 2x cada tick (hambre/sed suben 2x). Eventualmente muere.
+
+2. **Añadir constante** `ORPHAN_DECAY_MULTIPLIER = 2.0` para acelerar decaimiento de huérfanos.
+
+3. **Event types**: Añadir `"adoption"` a SimEvent types válidos.
+
+**Criterios de aceptación**:
+- [x] Cuando caregiver muere y hay adulto cercano → child es adoptado (parent_id actualizado)
+- [x] SimEvent "adoption" se loguea con descripción informativa
+- [x] Cuando caregiver muere sin adultos cerca → child entra en decadencia acelerada
+- [x] Test `test_orphan_adoption` pasa
+
+---
+
+### T21 — Crear `Faction` dataclass y `FactionManager`
+**Feature**: F4
+**Fase**: 4
+**Archivos**: `backend/app/simulation/faction.py` (NUEVO)
+**Depende de**: Ninguna (se puede hacer en paralelo con T18-T20)
+**Estimación**: Media
+
+**Descripción**:
+Crear nuevo módulo `backend/app/simulation/faction.py`:
+
+1. **`FactionSummary` dataclass** (para respuesta API):
+   ```python
+   @dataclass
+   class FactionSummary:
+       id: str
+       name: str
+       color: str
+       member_count: int
+       shared_resources: dict[str, int]
+   ```
+
+2. **`Faction` dataclass**:
+   ```python
+   @dataclass
+   class Faction:
+       id: str
+       name: str
+       color: str  # hex, e.g. "#FF0000"
+       member_ids: list[str] = field(default_factory=list)
+       shared_resources: dict[str, int] = field(default_factory=dict)
+   ```
+
+3. **`FactionManager` class**:
+   ```python
+   class FactionManager:
+       def __init__(self):
+           self.factions: dict[str, Faction] = {}
+       
+       def create(self, name: str, color: str) -> Faction
+       def delete(self, faction_id: str) -> bool
+       def join(self, agent_id: str, faction_id: str) -> bool  # returns False if full/error
+       def leave(self, agent_id: str, faction_id: str) -> bool
+       def list_all(self) -> list[FactionSummary]
+       def get_faction(self, faction_id: str) -> Faction | None
+       def transfer_inventory_on_death(self, agent) -> None  # agent.inventory → faction.shared_resources
+       def get_all(self) -> dict[str, Faction]
+   ```
+   - `create()` genera UUID para faction id
+   - `join()` añade agent_id a member_ids
+   - `leave()` remueve agent_id de member_ids
+   - `transfer_inventory_on_death()` suma cada item del inventario del agente a `shared_resources`
+
+4. **FactionManager config inicial**: Si no se pasa configuración de facciones, crear 3 facciones por defecto:
+   - "River Clan" (#00AAFF)
+   - "Stone Hold" (#FF8800)
+   - "Green Ward" (#44BB44)
+
+5. Registrar en `backend/app/simulation/__init__.py`.
+
+**Criterios de aceptación**:
+- [x] `Faction` dataclass con todos los campos requeridos
+- [x] `FactionManager` soporta CRUD completo (create, delete, join, leave, list)
+- [x] `transfer_inventory_on_death()` mueve inventario a shared_resources
+- [x] Facciones por defecto se crean si no se provee configuración
+- [x] Tests `test_faction_crud`, `test_faction_death_transfer` pasan
+
+---
+
+### T22 — Integrar facciones en el engine, snapshot y prompts
+**Feature**: F4
+**Fase**: 4
+**Archivos**: `backend/app/simulation/agent.py`, `backend/app/simulation/engine.py`, `backend/app/models/schemas.py`, `backend/app/simulation/snapshot.py`, `backend/app/ai/prompts.py`, `backend/app/simulation/event_queue.py`
+**Depende de**: T21
+**Estimación**: Alta
+
+**Descripción**:
+
+1. **Agent** (`agent.py`): Añadir `faction_id: str | None = None` al dataclass `Agent`.
+
+2. **Engine** (`engine.py`):
+   - En `__init__()`: instanciar `self.faction_manager = FactionManager()`.
+   - Al añadir agente (`add_agent()` o en start): asignar agente a una facción (distribuir uniformemente o aleatoria). Opción: mantener la lógica de distribución en el engine.
+   - En `_process_needs()`: cuando un agente muere, llamar a `self.faction_manager.transfer_inventory_on_death(agent)` si el agente pertenece a una facción.
+   - Añadir tick phase `_process_faction_agent_death(tick)` después de `_process_social_interactions()`.
+
+3. **Event types** (`event_queue.py`): Añadir `"faction_join"`, `"faction_leave"` a tipos válidos.
+
+4. **WorldSnapshot schema** (`schemas.py`):
+   - Añadir campo `factions: list[dict] = []` con lista de resúmenes de facciones.
+   - Añadir campo `colony_stats: dict | None = None` (placeholder para F7).
+
+5. **Snapshot builder** (`snapshot.py`):
+   - En `_build_agent_state()`: incluir `faction_id`.
+   - En `build()` y `build_delta()`: incluir `factions` desde `engine.faction_manager.list_all()` como lista de dicts.
+   - El builder necesita acceso al `faction_manager`. Pasar como parámetro en constructor o mantener referencia.
+
+6. **Prompts** (`prompts.py`):
+   - Añadir sección `FACTION:` en el prompt:
+   ```
+   FACTION:
+   - You are a member of "{faction_name}" (color: {faction_color})
+   ```
+   - Si no tiene facción: "(you are not in a faction)".
+   - En la sección de relaciones, si el otro agente es de la misma facción, añadir "(faction ally)".
+
+7. **Orchestrator** (`orchestrator.py`):
+   - Pasar `agent.faction_id` al build_prompt, resolver nombre de facción desde faction_manager si está disponible.
+
+**Criterios de aceptación**:
+- [x] Agent tiene `faction_id` con default None
+- [x] Engine instancia FactionManager y asigna facciones a agentes al iniciar
+- [x] Muerte de miembro de facción → inventory transferido a shared_resources
+- [x] Snapshot incluye lista de facciones con id, name, color, member_count, shared_resources
+- [x] Prompt incluye sección FACTION
+- [x] Tests de integración F4 pasan
+
+---
+
+### T23 — Tests de Fase 4 (F3 + F4)
+**Feature**: F3, F4
+**Fase**: 4
+**Archivos**: `backend/tests/test_social.py` (añadir)
+**Depende de**: T18, T19, T20, T21, T22
+**Estimación**: Baja
+
+**Descripción**:
+Implementar tests para F3 y F4:
+
+**F3 Tests:**
+- `test_child_blocks_eat` — is_child=True → handle_eat() falla/bloqueada
+- `test_feed_child_action` — Caregiver tiene berries, child cerca → hunger child baja, inventario caregiver baja
+- `test_child_stat_inheritance` — Stats parent ± random(0,15), child dentro de rango esperado
+- `test_child_maturity` — Tick llega a maturity_age → is_child=False
+- `test_orphan_adoption` — Caregiver muere, adulto más cercano dentro de radio adopta
+
+**F4 Tests:**
+- `test_faction_crud` — Create, delete, join, leave, list
+- `test_faction_death_transfer` — Agent muere → inventory se mueve a faction.shared_resources
+- `test_faction_defaults` — 3 facciones por defecto creadas al iniciar
+
+**Integration tests:**
+- `test_child_spawn_adjacent_to_parent` — Después de reproducción F8, child spawn adyacente
+- `test_faction_in_snapshot` — Snapshot incluye lista de facciones con datos correctos
+
+---
+
+## Fase 5 — Colony UI (F7: Panel de colonia + Widgets HUD)
+
+### T24 — Crear `ColonyStats` collector y endpoint REST `/api/colony`
+**Feature**: F7
+**Fase**: 5
+**Archivos**: `backend/app/simulation/colony.py` (NUEVO), `backend/app/models/schemas.py`, `backend/app/main.py` o nueva ruta
+**Depende de**: T22 (factions en snapshot), Fase 3 completa
+**Estimación**: Alta
+
+**Descripción**:
+
+1. **ColonyStats dataclass** (`colony.py`):
+   ```python
+   @dataclass
+   class ColonyStats:
+       population: int
+       births: int
+       deaths: int
+       role_distribution: dict[str, int]
+       sex_distribution: dict[str, int]
+       age_groups: dict[str, int]  # "child": N, "adult": N, "elder": N
+       total_resources: dict[str, int]
+       factions: list[FactionSummary]
+   ```
+   - `total_resources` = suma de todos los inventarios de todos los agentes
+   - `age_groups`: child = is_child=True, elder = age > max_age*0.7, adult = resto
+   - `births`/`deaths` = contadores de sesión (acumulados desde start)
+
+2. **ColonyStatsCollector** (`colony.py`):
+   ```python
+   class ColonyStatsCollector:
+       def __init__(self):
+           self.births = 0
+           self.deaths = 0
+       
+       def record_birth(self): self.births += 1
+       def record_death(self): self.deaths += 1
+       
+       def collect(self, agents: list[Agent], faction_manager) -> ColonyStats:
+           # Compute from current state
+   ```
+   - El engine debe llamar a `record_birth()` y `record_death()` cuando ocurren.
+
+3. **Engine** (`engine.py`):
+   - Instanciar `self.colony_stats_collector = ColonyStatsCollector()`.
+   - En creación de agente y muerte, llamar a `record_birth()` / `record_death()`.
+
+4. **REST endpoint** — Crear `backend/app/api/colony.py` o añadir a ruta existente:
+   ```python
+   @router.get("/api/colony")
+   async def get_colony_stats(request: Request):
+       engine = request.app.state.engine
+       stats = engine.colony_stats_collector.collect(engine.agents, engine.faction_manager)
+       return stats  # como dict
+   ```
+   - Requiere FastAPI, registrar router en `main.py` como `app.include_router(colony_router)`.
+
+5. **Schema Pydantic** (`schemas.py`):
+   - Añadir `class ColonyStatsResponse(BaseModel)` con todos los campos de ColonyStats.
+
+**Criterios de aceptación**:
+- [x] `ColonyStats` dataclass con todos los campos requeridos
+- [x] `ColonyStatsCollector.collect()` produce estadísticas correctas de la población actual
+- [x] `GET /api/colony` retorna JSON con estructura correcta
+- [x] births y deaths son contadores de sesión (no se resetean cada tick)
+- [x] Test `test_colony_endpoint` pasa
+
+---
+
+### T25 — Extender snapshot WebSocket con `colony_stats`
+**Feature**: F7
+**Fase**: 5
+**Archivos**: `backend/app/models/schemas.py`, `backend/app/simulation/snapshot.py`
+**Depende de**: T24
+**Estimación**: Baja
+
+**Descripción**:
+
+1. **WorldSnapshot schema** (`schemas.py`):
+   - Añadir campo `colony_stats: dict | None = None` al modelo `WorldSnapshot`.
+   - Debe incluir subset de ColonyStats: population, births, deaths, total_resources.
+
+2. **Snapshot builder** (`snapshot.py`):
+   - En `build()` y `build_delta()`: incluir `colony_stats` con:
+     ```python
+     colony_stats = {
+         "population": len(self.agents),
+         "births": colony_collector.births,
+         "deaths": colony_collector.deaths,
+         "total_resources": {... aggregated from all agents ...}
+     }
+     ```
+   - Requiere pasar `colony_stats_collector` al builder. Añadir como parámetro en `__init__()`.
+
+3. **Engine** (`engine.py`):
+   - Pasar `colony_stats_collector` al `WorldSnapshotBuilder` en `__init__()`.
+
+**Criterios de aceptación**:
+- [x] WorldSnapshot tiene campo `colony_stats` con population, births, deaths, total_resources
+- [x] Datos en snapshot coinciden con endpoint REST
+- [x] Test `test_colony_stats_in_snapshot` pasa
+
+---
+
+### T26 — Actualizar frontend store con `colony_stats` y `factions`
+**Feature**: F7
+**Fase**: 5
+**Archivos**: `frontend/src/lib/stores/simulationStore.svelte.js`
+**Depende de**: T25 (snapshot extendido), T22 (factions en snapshot)
+**Estimación**: Baja
+
+**Descripción**:
+
+1. **SimulationState typedef** — Añadir campos:
+   ```javascript
+   colony_stats: { population: number, births: number, deaths: number, total_resources: Record<string, number> } | null
+   factions: Record<string, { id: string, name: string, color: string, member_count: number, shared_resources: Record<string, number> }>
+   ```
+
+2. **INITIAL_STATE** — Añadir valores iniciales:
+   - `colony_stats: null`
+   - `factions: {}`
+
+3. **updateFromSnapshot()** — Consumir `colony_stats` y `factions` del snapshot payload:
+   ```javascript
+   colony_stats: data.colony_stats ?? state.colony_stats,
+   factions: data.factions ?? state.factions,
+   ```
+
+**Criterios de aceptación**:
+- [x] Store tiene campo `colony_stats` con valores correctos desde snapshot
+- [x] Store tiene campo `factions` con datos desde snapshot
+- [x] Datos persisten entre snapshots (no se resetean si no vienen en un tick)
+- [x] No rompe funcionalidad existente
+
+---
+
+### T27 — Crear `ColonyInfo.svelte`
+**Feature**: F7
+**Fase**: 5
+**Archivos**: `frontend/src/lib/components/ColonyInfo.svelte` (NUEVO)
+**Depende de**: T26 (store actualizado)
+**Estimación**: Media
+
+**Descripción**:
+
+Crear componente Svelte 5 que muestre un panel completo de información de la colonia:
+
+1. **Layout**: Panel plegable, estilo consistente con AgentInspector (fondo oscuro semi-transparente, misma tipografía).
+
+2. **Secciones**:
+   - **Population**: total, births (sesión), deaths (sesión)
+   - **Demographics**:
+     - Role distribution: barras simples (gatherer, builder, scout, etc.)
+     - Sex distribution: male/female counts
+     - Age groups: child / adult / elder counts
+   - **Total Resources**: tabla de recursos agregados (berries, wood, stone, etc.) con emojis
+   - **Active Factions**: tarjetas de cada facción con nombre, color swatch, member count, shared resources
+
+3. **Data source**: Suscribirse a `$simulationStore.colony_stats` y `$simulationStore.factions`.
+
+4. **Auto-refresh**: Se actualiza reactivamente via Svelte 5 stores (no polling). Cada snapshot actualiza los datos.
+
+5. **Posición**: Panel anclado a la derecha o como overlay. Opcional: mostrar/ocultar con botón en HUD.
+
+**Criterios de aceptación**:
+- [x] Panel muestra population, births, deaths correctamente
+- [x] Role/sex/age distribution se renderiza con barras o tabla
+- [x] Total resources suma correctamente
+- [x] Active factions muestra nombre, color, member_count, shared_resources
+- [x] Se actualiza automáticamente con cada snapshot vía store reactivity
+- [x] No rompe layout existente
+
+---
+
+### T28 — Crear `HudWidgets.svelte` con métricas clave de colonia
+**Feature**: F7
+**Fase**: 5
+**Archivos**: `frontend/src/lib/components/HudWidgets.svelte` (NUEVO)
+**Depende de**: T26 (store actualizado)
+**Estimación**: Baja
+
+**Descripción**:
+
+Crear componente minimalista de widgets HUD que muestre métricas clave de la colonia:
+
+1. **Widgets** (pequeños contadores numéricos):
+   - Population count (icono: 👥)
+   - Births this session (icono: 👶)
+   - Deaths this session (icono: 💀)
+   - Active factions (icono: 🚩)
+
+2. **Data source**: `$simulationStore.colony_stats` y `$simulationStore.factions`.
+
+3. **Posición**: Integrar en el HUD existente (`HUD.svelte`) o como barra separada cerca del HUD.
+
+4. **Estilo**: Mínimo, solo números con iconos pequeños. Mismo fondo que HUD existente.
+
+**Criterios de aceptación**:
+- [x] Widgets muestran population, births, deaths correctamente
+- [x] Se actualizan automáticamente vía store
+- [x] Estilo consistente con HUD existente
+
+---
+
+### T29 — Actualizar `AgentInspector` con relaciones, facción, conocimiento y child status
+**Feature**: F8, F4, F2, F3 (frontend)
+**Fase**: 5
+**Archivos**: `frontend/src/lib/components/AgentInspector.svelte`
+**Depende de**: T26 (store con datos actualizados)
+**Estimación**: Media
+
+**Descripción**:
+
+Añadir nuevas secciones al panel `AgentInspector.svelte`:
+
+1. **Relationships section** (F8):
+   - Lista de agentes conocidos: nombre, interaction_count, score (barra de color), last_interaction_tick
+   - Si no hay relaciones: "(no relationships yet)"
+
+2. **Faction section** (F4):
+   - Si `agent.faction_id` existe: mostrar nombre de facción + color swatch (círculo de color) al lado
+   - Si no: "(not in a faction)"
+
+3. **Knowledge section** (F2):
+   - Lista de subtipos conocidos (de `agent.knowledge` — array de strings)
+   - Si no hay: "(no special knowledge)"
+
+4. **Child Status section** (F3):
+   - Si `agent.is_child`: mostrar "🧒 Child", parent_id, maturity progress bar (age / maturity_age)
+   - Si no: mostrar "Adult"
+
+5. **Actualizar interface AgentData** con los nuevos campos:
+   ```typescript
+   interface AgentData {
+       // ... existing fields ...
+       relationships?: Record<string, { interaction_count: number, last_interaction_tick: number, score: number }>;
+       faction_id?: string;
+       knowledge?: string[];
+       is_child?: boolean;
+       parent_id?: string;
+       maturity_age?: number;
+   }
+   ```
+
+**Criterios de aceptación**:
+- [x] AgentInspector muestra sección "Relationships" con interacciones conocidas
+- [x] AgentInspector muestra facción con color swatch si aplica
+- [x] AgentInspector muestra subtipos conocidos en sección "Knowledge"
+- [x] AgentInspector muestra child status con barra de madurez
+- [x] No rompe secciones existentes (Vital Signs, Identity, Attributes, Inventory, Monologue, Prompt)
+
+---
+
+### T30 — Actualizar renderizado del canvas con colores de facción
+**Feature**: F4 (frontend)
+**Fase**: 5
+**Archivos**: `frontend/src/lib/canvas/entities.ts`, `frontend/src/lib/canvas/engine.ts` (si aplica)
+**Depende de**: T26 (store con datos de facciones)
+**Estimación**: Media
+
+**Descripción**:
+
+1. **AgentRenderData** (`entities.ts`):
+   - Añadir campo `factionColor: string | null = null`.
+
+2. **updateFromSnapshot()**:
+   - Leer `state.faction_id` desde el snapshot de cada agente.
+   - Resolver color desde `simulationStore.factions[state.faction_id]?.color`.
+   - Asignar a `a.factionColor`.
+
+   Alternativa: pasar faction_id y resolver en el draw step mediante un lookup map.
+
+3. **draw()**:
+   - Después de dibujar el círculo del agente, si `a.factionColor` no es null:
+     ```typescript
+     if (a.factionColor) {
+         ctx.beginPath();
+         ctx.arc(px, py, RADIUS + 3, 0, Math.PI * 2);
+         ctx.strokeStyle = a.factionColor;
+         ctx.lineWidth = 3;
+         ctx.stroke();
+     }
+     ```
+   - El borde coloreado se dibuja por fuera del círculo del role.
+
+4. **Faction color resolution**: El `entities.ts` necesita acceso a los datos de facciones. Opciones:
+   - Opción A: pasar `factions` dict como parámetro a `updateFromSnapshot()`.
+   - Opción B: resolver en el canvas engine (donde se llama a `updateFromSnapshot`) y pasar `factionColor` directamente.
+
+**Criterios de aceptación**:
+- [x] Agentes con facción muestran borde coloreado en el canvas
+- [x] Agentes sin facción no muestran borde extra
+- [x] Color del borde corresponde al color de la facción
+- [x] No rompe renderizado existente (sombras, nombres, hunger bars, emojis)
+
+---
+
+## Resumen de Dependencias
+
+```
+T1 ──→ T2 ──→ T6 (tests F1)
+  │
+  └──→ T3 ──→ T4 ──→ T5 ──→ T6 (tests F8)
+                │
+                └──→ T7 ──→ T8 ──→ T9 ──→ T10 (tests F6)
+                                    │
+                    ┌───────────────┘
+                    ▼
+T11 ──→ T12 ──→ T13 ──→ T16 ──→ T17 (tests F2)
+  │                 │
+  │                 └──→ T14 ──→ T15 ──→ T17 (tests F5)
+  │                               │
+  │                               └──→ T16 (knowledge share)
+  ▼
+T18 ──→ T19 ──→ T20 ──→ T23 (tests F3)
+  │
+  ├──→ T21 ──→ T22 ──→ T23 (tests F4)
+  │
+  └──→ T24 ──→ T25 ──→ T26 ──→ T27 (ColonyInfo)
+                                ├──→ T28 (HudWidgets)
+                                ├──→ T29 (AgentInspector)
+                                ├──→ T30 (Canvas factions)
+                                └──→ T31 (HUD updates)
+```
+
+## Estimación total por fase
+
+| Fase | Tareas | Archivos nuevos | Archivos modificados | Estimación |
+|------|--------|-----------------|---------------------|------------|
+| F1   | 6      | 0               | 4                   | ~3-4 días  |
+| F2   | 4      | 1               | 4                   | ~3-4 días  |
+| F3   | 7      | 0               | 7                   | ~4-5 días  |
+| F4   | 6      | 1               | 6                   | ~4-5 días  |
+| F5   | 7      | 3               | 5                   | ~3-4 días  |
+| **Total** | **30** | **5**        | **~12**             | **~17-22 días** |

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,62 @@
+schema: spec-driven
+
+context: |
+  Tech stack: Python/FastAPI backend (async, SQLAlchemy + aiosqlite, LiteLLM, WebSocket) + SvelteKit frontend (TypeScript, Svelte 5, Vite, Chart.js, Canvas API)
+  Architecture: Monorepo (npm workspaces) with two-service architecture — FastAPI backend (app/) with simulation engine + AI orchestration, SvelteKit frontend (frontend/) with reactive stores + Canvas 2D rendering
+  Communication: WebSocket (delta snapshots in real time)
+  Persistence: SQLite (events/metrics) + JSON configs (world/agents/rules) + ChromaDB (agent memory via LiteLLM)
+  Testing: pytest + pytest-asyncio (backend, 49 tests passing), svelte-check (frontend type check)
+  Style: ruff (Python linting + formatting), ESLint + Prettier (JS/TS/Svelte)
+
+strict_tdd: true
+
+testing:
+  runner:
+    command: python -m pytest tests/ -v
+    framework: pytest
+  layers:
+    unit:
+      available: true
+      tool: pytest
+    integration:
+      available: true
+      tool: httpx (ASGITransport)
+    e2e:
+      available: false
+      tool: null
+  coverage:
+    available: false
+    command: null
+  quality:
+    linter:
+      available: true
+      command: ruff check .
+    type_checker:
+      available: true
+      command: svelte-check (frontend) / N/A (backend)
+    formatter:
+      available: true
+      command: ruff format (backend) / prettier (frontend)
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Identify affected modules/packages
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+  tasks:
+    - Group tasks by phase (infrastructure, implementation, testing)
+    - Use hierarchical numbering (1.1, 1.2, etc.)
+    - Keep tasks small enough to complete in one session
+  apply:
+    - Follow existing code patterns and conventions
+    - Load relevant coding skills for the project stack
+  verify:
+    - Run tests if test infrastructure exists
+    - Compare implementation against every spec scenario
+  archive:
+    - Warn before merging destructive deltas (large removals)

--- a/openspec/specs/agent-society/spec.md
+++ b/openspec/specs/agent-society/spec.md
@@ -1,0 +1,180 @@
+# Spec: agent-society
+
+> Consolidated spec — synced from delta `openspec/changes/agent-society/specs/agent-society/spec.md`
+> Archive: `openspec/changes/archive/agent-society/archive-report.md`
+
+## Capabilities
+
+### capability: agent-society
+**Depends on**: simulation-engine
+
+Extends the core simulation with a full social simulation layer: relationships, conversations, trade, childhood dependency, factions, limited perception (knowledge), LLM action-feedback, and colony-level UI.
+
+#### Requirements
+
+**F1 — LLM-Triggered Action Feedback**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F1-R1 | The system MUST capture the `ActionResult` from each completed action (success/failure, stat deltas, inventory deltas, events produced) and pass it as structured context to the LLM on the agent's next `decide_next_action()` call. | MUST |
+| F1-R2 | The system MUST include the `ActionResult` context as a dedicated field in the LLM prompt (e.g., `last_action_result`) separate from the agent's current stats and world state. | MUST |
+| F1-R3 | If the agent has no prior action (first tick after spawn), the `last_action_result` field MUST be `null`/`None` instead of producing an error. | MUST |
+| F1-R4 | If the LLM call times out or fails, the agent MUST fall back to instinct behavior (find nearest food/water) and the pending `ActionResult` context MUST be discarded (not accumulated across ticks). | MUST |
+| F1-R5 | The `ActionResult` context MUST include the `ActionType` that was executed, the `success` boolean, and a summary of stat changes (e.g., `hunger:-30`, `wood:+5`). | MUST |
+
+**F2 — Limited Perception / Knowledge**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F2-R1 | Resources on the world grid MUST have a `subtype` field (e.g., `POISONOUS_BERRY`, `SAFE_BERRY`, `OAK_TREE`, `PINE_TREE`) in addition to the base `resource_type` (e.g., `BERRY`, `WOOD`). | MUST |
+| F2-R2 | Each resource subtype MUST define a set of `hidden_properties: dict[str, Any]` that are NOT visible to agents through vision/perception alone (e.g., `{"is_poisonous": true}` for `POISONOUS_BERRY`). | MUST |
+| F2-R3 | Agents MUST NOT receive `hidden_properties` in their world state snapshot — only the base `resource_type` and `subtype` name are visible. | MUST |
+| F2-R4 | When an agent consumes a resource (EAT action), the hidden properties of that resource's subtype MUST be revealed to the agent and stored in the agent's individual `knowledge` store. | MUST |
+| F2-R5 | Each agent MUST have an independent `knowledge: dict[str, dict[str, Any]]` store mapping `subtype_name -> {property: value}`. Agent A learning that `POISONOUS_BERRY` is poisonous does NOT mean Agent B knows it. | MUST |
+| F2-R6 | The agent's LLM prompt MUST include the agent's known knowledge as context when making decisions about resources (e.g., "You know that POISONOUS_BERRY is poisonous"). | MUST |
+| F2-R7 | Knowledge discovered by one agent MUST be shareable with another agent via the conversation system (F6). Shared knowledge is added to the receiving agent's `knowledge` store. | MUST |
+
+**F3 — Childhood and Parental Care**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F3-R1 | Newborn agents MUST be created with `is_child: bool = True` and `parent_id: str` pointing to their parent agent's ID. | MUST |
+| F3-R2 | Child agents MUST NOT be able to execute `EAT` or `DRINK` actions independently. If a child's FSM attempts to eat/drink, it MUST be blocked. | MUST |
+| F3-R3 | A new `FEED_CHILD` action type MUST be added. The caregiver executes `FEED_CHILD(child_id)` which transfers resources from the caregiver's inventory to satisfy the child's hunger/thirst. | MUST |
+| F3-R4 | A child agent MUST spawn adjacent to its parent (Manhattan distance ≤ 2). | MUST |
+| F3-R5 | The parent/caregiver's FSM MUST prioritize `FEED_CHILD` when the child's hunger or thirst exceeds a critical threshold (e.g., > 70), overriding the caregiver's own needs. | MUST |
+| F3-R6 | Child agents' initial stats (strength, intelligence, sociability) MUST be derived from the parent's stats with a random offset (e.g., `child.str = parent.str ± random(0, 15)`), clamped to [0, 100]. | MUST |
+| F3-R7 | Each child agent MUST have a `maturity_age: int` (in ticks). When `tick_count >= maturity_age`, `is_child` MUST be set to `False`, and `parent_id` MAY be cleared. After maturity, the agent gains full autonomy. | MUST |
+| F3-R8 | If a caregiver dies before the child matures, any nearby adult agent within interaction radius MAY adopt the child (auto-assigned via proximity). If no adult is within radius, the child's stats decay fatally. | MUST |
+
+**F4 — Factions**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F4-R1 | A new `Faction` data model MUST exist with fields: `id` (str), `name` (str), `color` (str, hex), `member_ids` (list[str]), `shared_resources` (dict[str, int]). | MUST |
+| F4-R2 | The `Agent` dataclass MUST gain an optional `faction_id: str | None` field. | MUST |
+| F4-R3 | Faction CRUD MUST be supported: create, delete, join (add member), leave (remove member), and list all factions. | MUST |
+| F4-R4 | The WebSocket snapshot MUST include faction information: each faction's id, name, color, member count, and total shared resources. | MUST |
+| F4-R5 | The frontend canvas MUST render agents with their faction's `color` as a border or overlay when the agent belongs to a faction. | MUST |
+| F4-R6 | When an agent's FSM evaluates trade requests (F5), same-faction agents MUST be preferred (higher acceptance probability in the LLM prompt context). | MUST |
+| F4-R7 | When a faction member dies, their personal inventory MUST be transferred to the faction's `shared_resources`. | MUST |
+
+**F5 — Trading**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F5-R1 | A new `TRADE` action type MUST be added to `ActionType` enum and registered in the action `REGISTRY`. | MUST |
+| F5-R2 | `TRADE` MUST be initiated by one agent (the proposer) targeting another agent within interaction radius (distance ≤ 3 tiles). The proposer specifies `offer: dict[str, int]` (what they give) and `request: dict[str, int]` (what they want). | MUST |
+| F5-R3 | The target agent's LLM MUST receive the trade proposal as context and decide to accept or reject based on the target's current needs, inventory, and relationship with the proposer. | MUST |
+| F5-R4 | If the target accepts, resources MUST be transferred atomically: proposer's inventory debited for `offer`, target's inventory debited for `request`, then both credited with the opposite side. If either side lacks sufficient resources, the trade MUST fail. | MUST |
+| F5-R5 | If the target rejects (or the LLM call times out), neither agent's inventory is modified. The rejection MUST be logged as a SimEvent. | MUST |
+| F5-R6 | A successful trade MUST increment the `interaction_count` between both agents (for F8 relationship tracking). | MUST |
+
+**F6 — Socialization and Conversations**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F6-R1 | A new `SOCIALIZE` action type MUST be added. The action is triggered automatically when two agents are within interaction radius (≤ 3 tiles). | MUST |
+| F6-R2 | Each agent MUST have a `conversation_queue: list[Message]` (FIFO, max 50 messages). Each `Message` contains: `sender_id`, `content` (structured dict), and `tick`. | MUST |
+| F6-R3 | When a proximity encounter is detected, a `Message` is enqueued in both agents' queues. The message content describes the encounter (e.g., `{"type": "greeting", "agent_name": "Alice"}`). | MUST |
+| F6-R4 | On each tick, an agent in IDLE state with non-empty `conversation_queue` MUST process the next message in its LLM prompt. The LLM decides how to respond (reply, share knowledge, ignore, propose trade, etc.). | MUST |
+| F6-R5 | Agents MAY share knowledge from their `knowledge` store (F2) through conversation. When an agent shares a known property, the receiving agent's `knowledge` store MUST be updated. | MUST |
+| F6-R6 | Each successful conversation interaction MUST increment the `interaction_count` for both participants, feeding into F8's relationship system. | MUST |
+| F6-R7 | All conversation events (initiation, messages, knowledge shared) MUST be recorded as SimEvents in the event log with type `"socialize"`. | MUST |
+| F6-R8 | To prevent tick-loop spam, a maximum of 5 conversation pairs per tick MUST be processed. Additional pending pairs are deferred to the next tick. | MUST |
+
+**F7 — Colony Information Panel**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F7-R1 | A new REST endpoint `GET /api/colony` MUST return colony-level statistics: total population, births count (agents spawned this session), deaths count, alive/dead ratio, distribution by role, sex, age groups, total resources across all agents, and active factions list. | MUST |
+| F7-R2 | The WebSocket snapshot MUST be extended with a `colony_stats` field containing a subset of frequently-changing metrics: population, births, deaths, and total resources. | MUST |
+| F7-R3 | A new `ColonyInfo.svelte` component MUST be created in the frontend that displays: population (total, births, deaths), demographic breakdown (role/age distribution as simple bars or table), total resources, and active factions. | MUST |
+| F7-R4 | The ColonyInfo panel MUST auto-refresh from the WebSocket snapshot data (no polling). The REST endpoint serves as the initial load and for detailed data not in the snapshot. | MUST |
+| F7-R5 | The frontend HUD MUST show key colony metrics as minimal widgets: population count, births this session, deaths this session. | MUST |
+
+**F8 — Relationship-Based Reproduction**
+
+| # | Requirement | Strength |
+|---|-------------|----------|
+| F8-R1 | The `Agent` dataclass MUST gain a `relationships: dict[str, RelationshipData]` field where the key is another agent's ID. `RelationshipData` contains: `interaction_count` (int), `last_interaction_tick` (int), and `score` (float, -1.0 to 1.0). | MUST |
+| F8-R2 | Every interaction (trade, conversation, shared-resource use) increments `interaction_count` for both agents and updates `score` based on interaction type (positive for trade/gift, neutral for conversation, negative for theft/conflict). | MUST |
+| F8-R3 | The `REPRODUCE` action MUST be gated by a configurable `INTERACTION_THRESHOLD` (default: 5). The agent's `_find_reproduction_partner()` method MUST only consider agents with `interaction_count >= INTERACTION_THRESHOLD`. | MUST |
+| F8-R4 | Relationship scores MUST decay over time: if `current_tick - last_interaction_tick > DECAY_INTERVAL` (e.g., 100 ticks), `interaction_count` decrements by 1 each additional tick (minimum 0). | MUST |
+| F8-R5 | The AgentInspector panel in the frontend MUST display a "Relationships" section listing each known agent's name, interaction count, and relationship score. | MUST |
+| F8-R6 | Relationship data MUST be included in the WebSocket snapshot per-agent so the frontend can render it. | MUST |
+| F8-R7 | Relationship-aware reproduction MUST replace the current unconditional reproduction logic. Agents with zero interactions MUST NOT be able to reproduce. | MUST |
+
+#### Scenarios
+
+**F1 — LLM-Triggered Action Feedback**
+
+- GIVEN an agent that just completed a `CHOP` action with `ActionResult(success=True, stat_deltas={"energy": -10}, inventory_deltas={"wood": +3})` WHEN the agent enters `LLM_TRIGGER` state THEN the LLM prompt includes `last_action_result: {type: "CHOP", success: true, effects: "energy:-10, wood:+3"}`
+- GIVEN a newly spawned agent with no prior action WHEN it enters `LLM_TRIGGER` for the first time THEN `last_action_result` is `null`/`None`
+- GIVEN an agent whose LLM call fails (timeout) WHEN FSM processes the failed future THEN the agent falls back to instinct behavior and `last_action_result` is NOT accumulated for the next LLM call
+- GIVEN an agent that completed a `DRINK` action (thirst satisfied) WHEN LLM prompt is built THEN the `last_action_result` includes the thirst change and the resource tile consumed
+
+**F2 — Limited Perception / Knowledge**
+
+- GIVEN a world with `POISONOUS_BERRY` subtype (hidden: `{"is_poisonous": true}`) WHEN an agent receives the world snapshot THEN the tile shows `resource_type="BERRY", subtype="POISONOUS_BERRY"` but does NOT include `is_poisonous`
+- GIVEN an agent consumes a `POISONOUS_BERRY` (EAT action) WHEN the action completes THEN the agent's `knowledge["POISONOUS_BERRY"]["is_poisonous"]` is `True`, and the agent loses health
+- GIVEN an agent with `knowledge={"POISONOUS_BERRY": {"is_poisonous": True}}` WHEN the LLM is queried about what to eat THEN the knowledge is included as context: "You know POISONOUS_BERRY is poisonous"
+- GIVEN Agent A knows `POISONOUS_BERRY` is poisonous and Agent B does NOT WHEN Agent A shares this knowledge via conversation THEN Agent B's `knowledge["POISONOUS_BERRY"]["is_poisonous"]` is set to `True`
+
+**F3 — Childhood and Parental Care**
+
+- GIVEN a newborn agent WHEN created THEN `is_child=True`, `parent_id` is set, and the agent spawns on a tile adjacent to the parent
+- GIVEN a child agent with hunger=90 (critical) WHEN its FSM ticks THEN the action is NOT EAT/DRINK — the child waits; the parent's FSM triggers `FEED_CHILD` instead
+- GIVEN a parent executes `FEED_CHILD(child_id)` with `inventory={"berry": 5}` WHEN the action completes THEN the child's hunger decreases by 30 and the parent's inventory decreases by 1 berry
+- GIVEN child agent with parent stats `strength=70, intelligence=50, sociability=30` WHEN the child is spawned THEN its stats are within `[55-85], [35-65], [15-45]` respectively (parent ±15)
+- GIVEN a child agent with `maturity_age=500` WHEN `tick_count >= 500` THEN `is_child=False` and the agent can independently eat/drink
+- GIVEN a caregiver agent dies while a child is still dependent WHEN the tick loop checks for adopters THEN a nearby adult within 3 tiles is assigned as new caregiver; if none exists, the child's health decays each tick until death
+
+**F4 — Factions**
+
+- GIVEN a faction with `color="#FF0000"` WHEN a member agent is rendered in the frontend canvas THEN the agent has a red border/overlay
+- GIVEN a faction member dies WHEN death is processed THEN the agent's inventory is transferred to the faction's `shared_resources`
+- GIVEN two agents in the same faction WHEN one proposes a trade THEN the LLM prompt includes context that they are faction allies, increasing acceptance likelihood
+- GIVEN a faction with 3 members WHEN queried via GET /api/factions THEN the response includes id, name, color, member_count=3, and shared_resources
+
+**F5 — Trading**
+
+- GIVEN Agent A at (10,10) and Agent B at (11,10) within interaction radius WHEN Agent A initiates TRADE with offer={"wood": 3} and request={"berry": 5} THEN the trade proposal is added to Agent B's conversation queue
+- GIVEN Agent B receives a trade proposal and its LLM accepts WHEN the trade is processed THEN Agent A loses 3 wood, Agent B loses 5 berry, Agent A gains 5 berry, Agent B gains 3 wood (atomic swap)
+- GIVEN Agent A has offer={"wood": 10} but only has 3 wood in inventory WHEN the trade is evaluated THEN the action fails with `success=False` and neither inventory is modified
+- GIVEN a successful trade between Agent A and Agent B WHEN the trade completes THEN both agents' `interaction_count` increments by 1
+
+**F6 — Socialization and Conversations**
+
+- GIVEN two agents within distance ≤ 3 tiles WHEN the proximity check runs THEN a `Message` is enqueued in both agents' `conversation_queue`
+- GIVEN an agent in IDLE state with `conversation_queue` containing 3 messages WHEN the FSM ticks THEN the agent processes the oldest message, the LLM receives the message context and produces a response plan
+- GIVEN Agent A shares knowledge about `POISONOUS_BERRY` via a conversation message WHEN Agent B processes the message THEN Agent B's `knowledge` store is updated with the shared information
+- GIVEN a conversation event WHEN it occurs THEN a SimEvent with type `"socialize"` is logged containing both agent IDs and message summary
+- GIVEN more than 5 conversation pairs are pending in a single tick WHEN the tick processes social interactions THEN only 5 pairs are processed and the remainder are deferred to the next tick
+
+**F7 — Colony Information Panel**
+
+- GIVEN a running simulation with 10 agents (3 births, 1 death) WHEN `GET /api/colony` is called THEN the response includes `population=9`, `births=3`, `deaths=1`, `alive=9`, `dead=1`, plus resource totals and faction list
+- GIVEN a WebSocket snapshot is broadcast WHEN the `colony_stats` field is present THEN the frontend ColonyInfo panel updates without additional API calls
+- GIVEN ColonyInfo.svelte is mounted and receives colony stats via the store WHEN stats change THEN the display auto-updates via Svelte 5 reactivity
+
+**F8 — Relationship-Based Reproduction**
+
+- GIVEN Agent A and Agent B have `interaction_count=0` WHEN Agent A's FSM evaluates reproduction partners THEN `_find_reproduction_partner()` returns `None`
+- GIVEN Agent A and Agent B have `interaction_count=7` (≥ threshold=5) WHEN Agent A's FSM evaluates reproduction partners THEN `_find_reproduction_partner()` returns Agent B's ID as a candidate
+- GIVEN two agents with `last_interaction_tick=100` at tick 300 WHEN the decay check runs THEN `interaction_count` has decremented by `floor((300-100)/DECAY_INTERVAL)` (minimum 0)
+- GIVEN the AgentInspector panel WHEN an agent has 2 relationships THEN the panel shows a "Relationships" section listing both agents with their interaction count and score
+- GIVEN an agent's relationships include Agent B with `score=0.8` WHEN Agent A evaluates trade with Agent B THEN the LLM receives the positive relationship score as favorable context
+
+#### Acceptance Criteria
+
+- [x] **F1**: An action's result (success/failure, stat changes, inventory changes) appears in the next LLM prompt as `last_action_result`. First-tick agents gracefully pass `null`. LLM timeouts fall back to instincts and do NOT accumulate stale context.
+- [x] **F2**: Resource subtypes have hidden properties not visible in the world snapshot. Agents learn properties by consuming the resource. Knowledge is per-agent (not shared globally). Knowledge is shareable via conversation. The LLM prompt includes known knowledge about resources.
+- [x] **F3**: Newborn agents are born adjacent to parent with `is_child=True`. Children cannot EAT/DRINK independently — the caregiver's FSM triggers FEED_CHILD. Stats are inherited with random offset. Children mature at `maturity_age` ticks. Orphaned children are adopted by nearest adult or die if none exists.
+- [x] **F4**: Faction CRUD works. Agents show faction color in the canvas. Agent death transfers inventory to faction shared pool. Same-faction members get trade preference via LLM context.
+- [x] **F5**: TRADE action works between nearby agents. Proposer specifies offer/request. Target LLM evaluates and accepts/rejects. Accepted trades execute atomically. Rejected trades log without inventory changes. Successful trades increment interaction counts.
+- [x] **F6**: Proximity-based conversations trigger automatically. Messages are enqueued FIFO (max 50). LLM processes messages during the next planning cycle. Knowledge is shared via conversation messages. Interaction counts increment. Events are logged. Cap of 5 conversation pairs per tick enforced.
+- [x] **F7**: `GET /api/colony` returns demographics and resource totals. WebSocket snapshot includes `colony_stats`. ColonyInfo.svelte renders population, births, deaths, resource totals, and factions. Frontend HUD shows key metric widgets.
+- [x] **F8**: `relationships` dict tracks interactions per agent pair. REPRODUCE is gated by `interaction_count >= INTERACTION_THRESHOLD`. Relationships decay over time without interaction. AgentInspector shows relationships. Unconditional reproduction is replaced.
+- [x] **Backward compatibility**: All existing simulation-engine tests pass without modification. Existing agents without `faction_id`, `is_child`, `knowledge`, or `relationships` continue to function with default values.
+- [ ] **Performance**: Tick loop with all social features active (20 agents, 3 factions, conversations, trades) completes within 150ms per tick on reference hardware.


### PR DESCRIPTION
Closes #1

## Summary
- Complete social simulation layer with 8 features (F1-F8)
- 9 new files, 14 modified files
- 114 tests passing, 0 ruff errors, 0 frontend TS errors

## Changes

| File | Change |
|------|--------|
| \ackend/app/simulation/conversation.py\ | NEW — ConversationManager, Message dataclass |
| \ackend/app/simulation/faction.py\ | NEW — Faction, FactionManager |
| \ackend/app/simulation/colony.py\ | NEW — ColonyStatsCollector |
| \ackend/app/api/colony.py\ | NEW — GET /api/colony REST endpoint |
| \ackend/tests/test_social.py\ | NEW — 58 tests covering all social features |
| \rontend/src/lib/components/ColonyInfo.svelte\ | NEW — Colony demographics panel |
| \rontend/src/lib/components/HudWidgets.svelte\ | NEW — HUD population widgets |
| \ackend/app/simulation/agent.py\ | MODIFIED — Relationships, knowledge, conversation_queue, childhood, faction fields |
| \ackend/app/simulation/engine.py\ | MODIFIED — Social managers integrated in tick loop |
| \ackend/app/simulation/actions.py\ | MODIFIED — TRADE, FEED_CHILD actions, ActionResult enriched |
| \ackend/app/simulation/world.py\ | MODIFIED — Tile subtype, hidden_properties |
| \ackend/app/simulation/snapshot.py\ | MODIFIED — Social fields in snapshots |
| \ackend/app/models/schemas.py\ | MODIFIED — Pydantic schemas for social data |
| \ackend/app/ai/prompts.py\ | MODIFIED — Action feedback, knowledge, faction, social context |
| \ackend/app/ai/orchestrator.py\ | MODIFIED — Faction context injection |
| \ackend/app/main.py\ | MODIFIED — Colony router registration |
| \rontend/src/lib/stores/simulationStore.svelte.js\ | MODIFIED — Colony stats, factions records |
| \rontend/src/lib/canvas/entities.ts\ | MODIFIED — Faction colors, child rendering |
| \rontend/src/lib/components/AgentInspector.svelte\ | MODIFIED — Relationships, knowledge, faction sections |
| \rontend/src/lib/components/HUD.svelte\ | MODIFIED — HudWidgets integration |
| \rontend/src/routes/+page.svelte\ | MODIFIED — ColonyInfo component |

## Test Plan
- [x] \python -m pytest tests/ -v\ — 114 passed
- [x] \uff check .\ — All checks passed
- [x] \
pm run check\ — 0 errors, 0 warnings
- [x] Reviewed via adversarial dual-judge protocol (Judgment Day) with 2 fix rounds

## Notes
SDD pipeline completed in automatic mode with hybrid artifact store. Full SDD artifacts archived in \openspec/changes/archive/agent-society/\.